### PR TITLE
Fix snapshot ID determinism and resolve all golangci-lint issues

### DIFF
--- a/pkg/driver/controller_nfs_test.go
+++ b/pkg/driver/controller_nfs_test.go
@@ -47,6 +47,10 @@ func TestCreateNFSVolume(t *testing.T) {
 				},
 			},
 			mockSetup: func(m *MockAPIClientForSnapshots) {
+				m.QueryAllDatasetsFunc = func(ctx context.Context, prefix string) ([]tnsapi.Dataset, error) {
+					// No existing datasets - allow creation
+					return []tnsapi.Dataset{}, nil
+				}
 				m.CreateDatasetFunc = func(ctx context.Context, params tnsapi.DatasetCreateParams) (*tnsapi.Dataset, error) {
 					return &tnsapi.Dataset{
 						ID:         "tank/csi/test-nfs-volume",
@@ -107,6 +111,10 @@ func TestCreateNFSVolume(t *testing.T) {
 				// No capacity specified - should default to 1GB
 			},
 			mockSetup: func(m *MockAPIClientForSnapshots) {
+				m.QueryAllDatasetsFunc = func(ctx context.Context, prefix string) ([]tnsapi.Dataset, error) {
+					// No existing datasets - allow creation
+					return []tnsapi.Dataset{}, nil
+				}
 				m.CreateDatasetFunc = func(ctx context.Context, params tnsapi.DatasetCreateParams) (*tnsapi.Dataset, error) {
 					return &tnsapi.Dataset{
 						ID:         "tank/test-nfs-volume-default",

--- a/pkg/driver/controller_nvmeof_test.go
+++ b/pkg/driver/controller_nvmeof_test.go
@@ -48,6 +48,10 @@ func TestCreateNVMeOFVolume(t *testing.T) {
 				},
 			},
 			mockSetup: func(m *MockAPIClientForSnapshots) {
+				m.QueryAllDatasetsFunc = func(ctx context.Context, prefix string) ([]tnsapi.Dataset, error) {
+					// No existing ZVOLs - allow creation
+					return []tnsapi.Dataset{}, nil
+				}
 				m.GetNVMeOFSubsystemByNQNFunc = func(ctx context.Context, nqn string) (*tnsapi.NVMeOFSubsystem, error) {
 					if nqn != "nqn.2024-11.ai.truenas:nvme:test-subsystem" {
 						t.Errorf("Expected NQN nqn.2024-11.ai.truenas:nvme:test-subsystem, got %s", nqn)
@@ -140,6 +144,10 @@ func TestCreateNVMeOFVolume(t *testing.T) {
 				// No capacity specified - should default to 1GB
 			},
 			mockSetup: func(m *MockAPIClientForSnapshots) {
+				m.QueryAllDatasetsFunc = func(ctx context.Context, prefix string) ([]tnsapi.Dataset, error) {
+					// No existing ZVOLs - allow creation
+					return []tnsapi.Dataset{}, nil
+				}
 				m.GetNVMeOFSubsystemByNQNFunc = func(ctx context.Context, nqn string) (*tnsapi.NVMeOFSubsystem, error) {
 					return &tnsapi.NVMeOFSubsystem{ID: 100, NQN: nqn}, nil
 				}
@@ -250,6 +258,10 @@ func TestCreateNVMeOFVolume(t *testing.T) {
 				},
 			},
 			mockSetup: func(m *MockAPIClientForSnapshots) {
+				m.QueryAllDatasetsFunc = func(ctx context.Context, prefix string) ([]tnsapi.Dataset, error) {
+					// No existing ZVOLs - will proceed to subsystem check
+					return []tnsapi.Dataset{}, nil
+				}
 				m.GetNVMeOFSubsystemByNQNFunc = func(ctx context.Context, nqn string) (*tnsapi.NVMeOFSubsystem, error) {
 					return nil, errors.New("subsystem not found")
 				}

--- a/pkg/driver/controller_snapshot_test.go
+++ b/pkg/driver/controller_snapshot_test.go
@@ -286,7 +286,7 @@ func TestEncodeDecodeSnapshotID(t *testing.T) {
 				return
 			}
 
-			// Verify decoded metadata matches original
+			// Verify decoded metadata matches original (except CreatedAt which is excluded from encoding)
 			if decoded.SnapshotName != tt.meta.SnapshotName {
 				t.Errorf("SnapshotName = %v, want %v", decoded.SnapshotName, tt.meta.SnapshotName)
 			}
@@ -299,8 +299,10 @@ func TestEncodeDecodeSnapshotID(t *testing.T) {
 			if decoded.Protocol != tt.meta.Protocol {
 				t.Errorf("Protocol = %v, want %v", decoded.Protocol, tt.meta.Protocol)
 			}
-			if decoded.CreatedAt != tt.meta.CreatedAt {
-				t.Errorf("CreatedAt = %v, want %v", decoded.CreatedAt, tt.meta.CreatedAt)
+			// CreatedAt is intentionally excluded from encoding (json:"-" tag) to ensure deterministic snapshot IDs
+			// It should always be 0 after decoding
+			if decoded.CreatedAt != 0 {
+				t.Errorf("CreatedAt = %v, want 0 (CreatedAt is excluded from snapshot ID encoding)", decoded.CreatedAt)
 			}
 		})
 	}

--- a/pkg/tnsapi/client.go
+++ b/pkg/tnsapi/client.go
@@ -655,6 +655,7 @@ type Dataset struct {
 	Available  map[string]interface{} `json:"available,omitempty"`
 	Used       map[string]interface{} `json:"used,omitempty"`
 	Mountpoint string                 `json:"mountpoint,omitempty"`
+	Volsize    map[string]interface{} `json:"volsize,omitempty"` // ZVOL size (for VOLUME type datasets)
 }
 
 // CreateDataset creates a new ZFS dataset.


### PR DESCRIPTION
## Summary
- Fix snapshot ID determinism by excluding CreatedAt timestamp from encoding to ensure consistent IDs for idempotency
- Resolve all 20 golangci-lint issues (goimports, govet, gocritic, unparam, nolintlint) for improved code quality
- Improve CSI spec compliance by returning InvalidArgument for malformed snapshot/volume IDs in ListSnapshots

## Details
- **Snapshot ID Determinism**: Changed `CreatedAt` field to use `json:"-"` tag to exclude from ID encoding, preventing non-deterministic IDs
- **golangci-lint Fixes**: Resolved variable shadowing (err → shareErr, scanErr, encodeErr, createErr, subsysErr, nsErr), formatting issues, and unused code
- **Test Updates**: Added QueryAllDatasetsFunc to test mocks for volume creation idempotency checks
- **Code Quality**: Added nolint directives for architectural complexity in createNFSVolume and createNVMeOFVolume

## Testing
- ✅ All 100 driver unit tests passing
- ✅ golangci-lint reports 0 issues
- ⏳ Integration tests (NFS and NVMe-oF) will run via GitHub Actions on self-hosted runner

## Related
Continues work from Phase 4 (#17) to improve CSI sanity test coverage and spec compliance.