### PR TITLE
feat: add configurable mount options for NFS and NVMe-oF volumes

### DIFF
--- a/charts/tns-csi-driver/values.yaml
+++ b/charts/tns-csi-driver/values.yaml
@@ -233,7 +233,10 @@ storageClasses:
     volumeBindingMode: Immediate
     # Allow volume expansion
     allowVolumeExpansion: true
-    # Mount options for NFS
+    # Mount options for NFS volumes
+    # These are merged with driver defaults (vers=4.2, nolock on Linux)
+    # User-specified options override defaults if there's a conflict
+    # Example: ["hard", "nointr", "rsize=1048576", "wsize=1048576"]
     mountOptions: []
     # Additional parameters
     parameters: {}
@@ -264,6 +267,10 @@ storageClasses:
     # (snapshot reference) to CreateVolume, resulting in empty volumes instead of clones.
     volumeBindingMode: Immediate
     allowVolumeExpansion: true
+    # Mount options for NVMe-oF filesystem volumes
+    # These are merged with driver defaults (noatime)
+    # User-specified options override defaults if there's a conflict
+    # Example: ["discard", "nodiscard", "data=ordered"]
     mountOptions: []
     parameters: {}
 

--- a/pkg/driver/node_nfs_darwin.go
+++ b/pkg/driver/node_nfs_darwin.go
@@ -2,8 +2,49 @@
 
 package driver
 
-// getNFSMountOptions returns platform-specific NFS mount options.
+// Default NFS mount options for macOS.
 // macOS supports NFSv3 and NFSv4 (but not v4.2).
-func getNFSMountOptions() []string {
-	return []string{"vers=4", "nolock"}
+var defaultNFSMountOptions = []string{"vers=4", "nolock"}
+
+// getNFSMountOptions merges user-provided mount options with sensible defaults.
+// User options take precedence - if a user specifies an option that conflicts
+// with a default (e.g., "vers=3" vs default "vers=4"), the user's option wins.
+// This allows StorageClass mountOptions to fully customize NFS mount behavior.
+func getNFSMountOptions(userOptions []string) []string {
+	if len(userOptions) == 0 {
+		return defaultNFSMountOptions
+	}
+
+	// Build a map of option keys that the user has specified
+	// This handles both key=value options (e.g., "vers=3") and flags (e.g., "nolock")
+	userOptionKeys := make(map[string]bool)
+	for _, opt := range userOptions {
+		key := extractOptionKey(opt)
+		userOptionKeys[key] = true
+	}
+
+	// Start with user options, then add defaults that don't conflict
+	result := make([]string, 0, len(userOptions)+len(defaultNFSMountOptions))
+	result = append(result, userOptions...)
+
+	for _, defaultOpt := range defaultNFSMountOptions {
+		key := extractOptionKey(defaultOpt)
+		if !userOptionKeys[key] {
+			result = append(result, defaultOpt)
+		}
+	}
+
+	return result
+}
+
+// extractOptionKey extracts the key from a mount option.
+// For "key=value" options, returns "key".
+// For flag options like "nolock" or "ro", returns the flag itself.
+func extractOptionKey(option string) string {
+	for i, c := range option {
+		if c == '=' {
+			return option[:i]
+		}
+	}
+	return option
 }

--- a/pkg/driver/node_nfs_linux.go
+++ b/pkg/driver/node_nfs_linux.go
@@ -2,8 +2,49 @@
 
 package driver
 
-// getNFSMountOptions returns platform-specific NFS mount options.
-// Linux supports NFSv4.2.
-func getNFSMountOptions() []string {
-	return []string{"vers=4.2", "nolock"}
+// Default NFS mount options for Linux.
+// These are used when no mount options are specified in the StorageClass.
+var defaultNFSMountOptions = []string{"vers=4.2", "nolock"}
+
+// getNFSMountOptions merges user-provided mount options with sensible defaults.
+// User options take precedence - if a user specifies an option that conflicts
+// with a default (e.g., "vers=3" vs default "vers=4.2"), the user's option wins.
+// This allows StorageClass mountOptions to fully customize NFS mount behavior.
+func getNFSMountOptions(userOptions []string) []string {
+	if len(userOptions) == 0 {
+		return defaultNFSMountOptions
+	}
+
+	// Build a map of option keys that the user has specified
+	// This handles both key=value options (e.g., "vers=3") and flags (e.g., "nolock")
+	userOptionKeys := make(map[string]bool)
+	for _, opt := range userOptions {
+		key := extractOptionKey(opt)
+		userOptionKeys[key] = true
+	}
+
+	// Start with user options, then add defaults that don't conflict
+	result := make([]string, 0, len(userOptions)+len(defaultNFSMountOptions))
+	result = append(result, userOptions...)
+
+	for _, defaultOpt := range defaultNFSMountOptions {
+		key := extractOptionKey(defaultOpt)
+		if !userOptionKeys[key] {
+			result = append(result, defaultOpt)
+		}
+	}
+
+	return result
+}
+
+// extractOptionKey extracts the key from a mount option.
+// For "key=value" options, returns "key".
+// For flag options like "nolock" or "ro", returns the flag itself.
+func extractOptionKey(option string) string {
+	for i, c := range option {
+		if c == '=' {
+			return option[:i]
+		}
+	}
+	return option
 }


### PR DESCRIPTION
Allow users to specify custom mount options via StorageClass mountOptions field. User-specified options are merged with sensible defaults, with user options taking precedence for conflicting keys.

Default mount options:
- NFS (Linux): vers=4.2, nolock
- NFS (macOS): vers=4, nolock
- NVMe-oF: noatime

Changes:
- Add getNFSMountOptions() to merge user options with defaults
- Add getNVMeOFMountOptions() for NVMe-oF filesystem mounts
- Update stageNFSVolume/formatAndMountNVMeDevice to read VolumeCapability mount flags
- Add documentation for mountOptions in Helm chart values.yaml
- Add unit tests for mount options merging logic

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark relevant items with an 'x' -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation
<!-- Why is this change needed? What problem does it solve? -->

## Changes Made
<!-- List the key changes made in this PR -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->

**Test environment:**
- Kubernetes version:
- TrueNAS version:
- Protocol tested: [ ] NFS [ ] NVMe-oF [ ] Both

**Tests run:**
- [ ] Unit tests (`make test`)
- [ ] Linting (`make lint`)
- [ ] Sanity tests
- [ ] Integration tests (manual or CI)

## Documentation
<!-- Have you updated relevant documentation? -->
- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)
- [ ] No documentation needed

## Checklist
<!-- Ensure all items are complete before requesting review -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Considerations
<!-- Any security implications of this change? -->
- [ ] This PR does not introduce security vulnerabilities
- [ ] No secrets or credentials are included in this PR
- [ ] I have reviewed SECURITY.md and followed best practices

## Related Issues
<!-- Link any related issues here -->
Fixes #
Related to #

## Additional Notes
<!-- Any additional information reviewers should know -->
