### PR TITLE
feat: add deleteStrategy parameter to retain volumes on PVC deletion

### DIFF
--- a/charts/tns-csi-driver/values.yaml
+++ b/charts/tns-csi-driver/values.yaml
@@ -236,6 +236,14 @@ storageClasses:
     # Mount options for NFS
     mountOptions: []
     # Additional parameters
+    # Available parameters:
+    #   deleteStrategy: "delete" or "retain"
+    #     - "delete" (default): Volume is deleted when PVC is deleted
+    #     - "retain": Volume is kept on TrueNAS when PVC is deleted (useful for data protection)
+    #   zfs.compression: ZFS compression algorithm (e.g., "lz4", "zstd", "off")
+    #   zfs.dedup: ZFS deduplication (e.g., "on", "off", "verify")
+    #   zfs.atime: Access time updates (e.g., "on", "off")
+    #   zfs.sync: Sync writes (e.g., "standard", "always", "disabled")
     parameters: {}
   
   # NVMe-oF storage class (requires Linux with nvme-tcp kernel module)
@@ -265,6 +273,15 @@ storageClasses:
     volumeBindingMode: Immediate
     allowVolumeExpansion: true
     mountOptions: []
+    # Additional parameters
+    # Available parameters:
+    #   deleteStrategy: "delete" or "retain"
+    #     - "delete" (default): Volume is deleted when PVC is deleted
+    #     - "retain": Volume is kept on TrueNAS when PVC is deleted (useful for data protection)
+    #   zfs.compression: ZFS compression algorithm (e.g., "lz4", "zstd", "off")
+    #   zfs.dedup: ZFS deduplication (e.g., "on", "off", "verify")
+    #   zfs.sync: Sync writes (e.g., "standard", "always", "disabled")
+    #   zfs.volblocksize: ZVOL block size (e.g., "16K", "64K")
     parameters: {}
 
 # Snapshot support

--- a/pkg/tnsapi/properties.go
+++ b/pkg/tnsapi/properties.go
@@ -64,6 +64,11 @@ const (
 	// Value: "nfs" or "nvmeof".
 	PropertyProtocol = "tns-csi:protocol"
 
+	// PropertyDeleteStrategy stores the deletion strategy for the volume.
+	// Value: "delete" (default) or "retain".
+	// When "retain", the volume will not be deleted when the PVC is deleted.
+	PropertyDeleteStrategy = "tns-csi:delete_strategy"
+
 	// ManagedByValue is the value stored in PropertyManagedBy.
 	ManagedByValue = "tns-csi"
 
@@ -78,6 +83,12 @@ const (
 
 	// ContentSourceVolume indicates the volume was created from another volume (clone).
 	ContentSourceVolume = "volume"
+
+	// DeleteStrategyDelete is the default strategy - volume is deleted when PVC is deleted.
+	DeleteStrategyDelete = "delete"
+
+	// DeleteStrategyRetain means the volume is retained when PVC is deleted.
+	DeleteStrategyRetain = "retain"
 )
 
 // PropertyNames returns all tns-csi property names for querying.
@@ -95,22 +106,24 @@ func PropertyNames() []string {
 		PropertyContentSourceID,
 		PropertyProvisionedAt,
 		PropertyProtocol,
+		PropertyDeleteStrategy,
 	}
 }
 
 // NFSVolumeProperties returns properties to set when creating an NFS volume.
-func NFSVolumeProperties(volumeName string, shareID int, provisionedAt string) map[string]string {
+func NFSVolumeProperties(volumeName string, shareID int, provisionedAt, deleteStrategy string) map[string]string {
 	return map[string]string{
-		PropertyManagedBy:     ManagedByValue,
-		PropertyCSIVolumeName: volumeName,
-		PropertyNFSShareID:    intToString(shareID),
-		PropertyProtocol:      ProtocolNFS,
-		PropertyProvisionedAt: provisionedAt,
+		PropertyManagedBy:      ManagedByValue,
+		PropertyCSIVolumeName:  volumeName,
+		PropertyNFSShareID:     intToString(shareID),
+		PropertyProtocol:       ProtocolNFS,
+		PropertyProvisionedAt:  provisionedAt,
+		PropertyDeleteStrategy: deleteStrategy,
 	}
 }
 
 // NVMeOFVolumeProperties returns properties to set when creating an NVMe-oF volume.
-func NVMeOFVolumeProperties(volumeName string, subsystemID, namespaceID int, subsystemNQN, provisionedAt string) map[string]string {
+func NVMeOFVolumeProperties(volumeName string, subsystemID, namespaceID int, subsystemNQN, provisionedAt, deleteStrategy string) map[string]string {
 	return map[string]string{
 		PropertyManagedBy:        ManagedByValue,
 		PropertyCSIVolumeName:    volumeName,
@@ -119,6 +132,7 @@ func NVMeOFVolumeProperties(volumeName string, subsystemID, namespaceID int, sub
 		PropertyNVMeSubsystemNQN: subsystemNQN,
 		PropertyProtocol:         ProtocolNVMeOF,
 		PropertyProvisionedAt:    provisionedAt,
+		PropertyDeleteStrategy:   deleteStrategy,
 	}
 }
 


### PR DESCRIPTION
Add support for a deleteStrategy StorageClass parameter that controls whether volumes are actually deleted or retained when a PVC is deleted.

- Add PropertyDeleteStrategy ZFS property (tns-csi:delete_strategy)
- Add DeleteStrategyDelete ("delete") and DeleteStrategyRetain ("retain") constants
- Update NFSVolumeProperties and NVMeOFVolumeProperties to store the strategy
- Update deleteNFSVolume and deleteNVMeOFVolume to check the strategy
- When strategy is "retain", CSI returns success but keeps all resources
- Document deleteStrategy parameter in Helm values.yaml

Usage: Set deleteStrategy: "retain" in StorageClass parameters to keep volumes on TrueNAS when PVCs are deleted. Useful for data protection.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark relevant items with an 'x' -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation
<!-- Why is this change needed? What problem does it solve? -->

## Changes Made
<!-- List the key changes made in this PR -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->

**Test environment:**
- Kubernetes version:
- TrueNAS version:
- Protocol tested: [ ] NFS [ ] NVMe-oF [ ] Both

**Tests run:**
- [ ] Unit tests (`make test`)
- [ ] Linting (`make lint`)
- [ ] Sanity tests
- [ ] Integration tests (manual or CI)

## Documentation
<!-- Have you updated relevant documentation? -->
- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)
- [ ] No documentation needed

## Checklist
<!-- Ensure all items are complete before requesting review -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Considerations
<!-- Any security implications of this change? -->
- [ ] This PR does not introduce security vulnerabilities
- [ ] No secrets or credentials are included in this PR
- [ ] I have reviewed SECURITY.md and followed best practices

## Related Issues
<!-- Link any related issues here -->
Fixes #
Related to #

## Additional Notes
<!-- Any additional information reviewers should know -->
