### PR TITLE
fix: initial snapshot handling improvements

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -37,6 +37,7 @@ const (
 	VolumeContextKeyExpectedCapacity  = "expectedCapacity"
 	VolumeContextKeyClonedFromSnap    = "clonedFromSnapshot"
 	VolumeContextValueTrue            = "true"
+	VolumeContextValueFalse           = "false"
 )
 
 // Static errors for controller operations.

--- a/pkg/driver/controller_snapshot_test.go
+++ b/pkg/driver/controller_snapshot_test.go
@@ -242,6 +242,11 @@ func (m *MockAPIClientForSnapshots) SetDatasetProperties(ctx context.Context, da
 	return nil
 }
 
+func (m *MockAPIClientForSnapshots) SetSnapshotProperties(ctx context.Context, snapshotID string, updateProperties map[string]string, removeProperties []string) error {
+	// Mock implementation - always succeed
+	return nil
+}
+
 func (m *MockAPIClientForSnapshots) GetDatasetProperties(ctx context.Context, datasetID string, propertyNames []string) (map[string]string, error) {
 	// Mock implementation - return empty map (no properties)
 	return make(map[string]string), nil

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -197,6 +197,10 @@ func (m *mockAPIClient) SetDatasetProperties(ctx context.Context, datasetID stri
 	return nil // Stub implementation
 }
 
+func (m *mockAPIClient) SetSnapshotProperties(ctx context.Context, snapshotID string, updateProperties map[string]string, removeProperties []string) error {
+	return nil // Stub implementation
+}
+
 func (m *mockAPIClient) GetDatasetProperties(ctx context.Context, datasetID string, propertyNames []string) (map[string]string, error) {
 	return make(map[string]string), nil // Stub implementation - returns empty properties
 }

--- a/pkg/tnsapi/client_test.go
+++ b/pkg/tnsapi/client_test.go
@@ -503,7 +503,11 @@ func TestErrorFormatting(t *testing.T) {
 			err: &Error{
 				Code:    404,
 				Message: "Not found",
-				Data:    map[string]string{"detail": "resource missing"},
+				Data: &ErrorData{
+					Error:     1,
+					ErrorName: "ResourceMissing",
+					Reason:    "resource cannot be located",
+				},
 			},
 			wantContain: "Storage API error 404: Not found",
 		},

--- a/pkg/tnsapi/interface.go
+++ b/pkg/tnsapi/interface.go
@@ -22,6 +22,7 @@ type ClientInterface interface {
 	QueryAllDatasets(ctx context.Context, prefix string) ([]Dataset, error)
 
 	// ZFS User Property operations (for CSI metadata tracking)
+	SetSnapshotProperties(ctx context.Context, snapshotID string, updateProperties map[string]string, removeProperties []string) error
 	SetDatasetProperties(ctx context.Context, datasetID string, properties map[string]string) error
 	GetDatasetProperties(ctx context.Context, datasetID string, propertyNames []string) (map[string]string, error)
 	GetAllDatasetProperties(ctx context.Context, datasetID string) (map[string]string, error)


### PR DESCRIPTION
## Description

While trying to use detached snapshots I noticed some errors in how things are handled. Including the unmarshaling of the date in the response, the naming schema not working for the detached snapshot, the metadata not being set properly on the detached dataset due to the wrong method being used, no metadata being set on regular snapshots. Lastly, deletion of detached snapshots isn't working and still isn't working.

To improve readability he unmarshaling of errors was also changed so they don't include the full stack trace from the API server anymore as that's likely useless for the client.

The PR in the current state fixes a number of issues, but more still remain. Overall, I believe the metadata on snapshots/datasets might need some improvements. I believe there's also some inconsistencies with key naming and naming in the code.

More fundamentally, the way regular snapshots are being discovered now is very inefficient and likely won't scale with a large number of snapshots. My current idea is to call the API on startup to list all snapshots and datasets, parse them with their metadata and put them in the `SnapshotRegistry` to function as a cache. Then add subscriptions to watch for snapshot and dataset events so that this cache is up to date. This will allow for much more efficient finding of the parent dataset and other values, without relying on back tracking the delete request to the VolumeSnapshotClass.

Given the planned improvements and possible necessity of multiple breaking changes I'm opening this PR as a draft as I continue to work on this to prevent multiple half implemented PRs. However, if wanted it can also be merged and worked on more iteratively. Needless to say, I'm open for any comments and discussions and will update the PR description as I go along. 


## Type of Change
<!-- Mark relevant items with an 'x' -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation
<!-- Why is this change needed? What problem does it solve? -->

## Changes Made
<!-- List the key changes made in this PR -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->

**Test environment:**
- Kubernetes version:
- TrueNAS version:
- Protocol tested: [ ] NFS [ ] NVMe-oF [ ] Both

**Tests run:**
- [ ] Unit tests (`make test`)
- [ ] Linting (`make lint`)
- [ ] Sanity tests
- [ ] Integration tests (manual or CI)

## Documentation
<!-- Have you updated relevant documentation? -->
- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)
- [ ] No documentation needed

## Checklist
<!-- Ensure all items are complete before requesting review -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Considerations
<!-- Any security implications of this change? -->
- [ ] This PR does not introduce security vulnerabilities
- [ ] No secrets or credentials are included in this PR
- [ ] I have reviewed SECURITY.md and followed best practices

## Related Issues
<!-- Link any related issues here -->
Fixes #
Related to #

## Additional Notes
<!-- Any additional information reviewers should know -->
