### PR TITLE
Make NVMe-oF discovery command optional

### DIFF
--- a/charts/tns-csi-driver/templates/node.yaml
+++ b/charts/tns-csi-driver/templates/node.yaml
@@ -55,6 +55,9 @@ spec:
             {{- if .Values.truenas.skipTLSVerify }}
             - "--skip-tls-verify"
             {{- end }}
+            {{- if .Values.node.enableNVMeDiscovery }}
+            - "--enable-nvme-discovery"
+            {{- end }}
           env:
             - name: NODE_ID
               valueFrom:

--- a/charts/tns-csi-driver/values.yaml
+++ b/charts/tns-csi-driver/values.yaml
@@ -144,6 +144,12 @@ node:
   # Affinity for node pods
   affinity: {}
   
+  # NVMe-oF optimization settings
+  # Skip redundant nvme discover before nvme connect.
+  # All connection params (NQN, server, port, transport) are already known from volume context.
+  # Enable only if you need discovery for multi-path or dynamic target topologies.
+  enableNVMeDiscovery: false
+
   # Update strategy for DaemonSet
   updateStrategy:
     type: RollingUpdate

--- a/cmd/tns-csi-driver/main.go
+++ b/cmd/tns-csi-driver/main.go
@@ -27,8 +27,9 @@ var (
 	apiKey        = flag.String("api-key", "", "Storage system API key")
 	metricsAddr   = flag.String("metrics-addr", ":8080", "Address to expose Prometheus metrics")
 	skipTLSVerify = flag.Bool("skip-tls-verify", false, "Skip TLS certificate verification (for self-signed certificates)")
-	showVersion   = flag.Bool("show-version", false, "Show version and exit")
-	debug         = flag.Bool("debug", false, "Enable debug logging (equivalent to -v=4)")
+	showVersion         = flag.Bool("show-version", false, "Show version and exit")
+	debug               = flag.Bool("debug", false, "Enable debug logging (equivalent to -v=4)")
+	enableNVMeDiscovery = flag.Bool("enable-nvme-discovery", false, "Run nvme discover before nvme connect (default: false, all connection params are known from volume context)")
 )
 
 func main() {
@@ -71,14 +72,15 @@ func main() {
 	klog.V(4).Infof("Node ID: %s", *nodeID)
 
 	drv, err := driver.NewDriver(driver.Config{
-		DriverName:    *driverName,
-		Version:       version,
-		NodeID:        *nodeID,
-		Endpoint:      *endpoint,
-		APIURL:        *apiURL,
-		APIKey:        *apiKey,
-		MetricsAddr:   *metricsAddr,
-		SkipTLSVerify: *skipTLSVerify,
+		DriverName:          *driverName,
+		Version:             version,
+		NodeID:              *nodeID,
+		Endpoint:            *endpoint,
+		APIURL:              *apiURL,
+		APIKey:              *apiKey,
+		MetricsAddr:         *metricsAddr,
+		SkipTLSVerify:       *skipTLSVerify,
+		EnableNVMeDiscovery: *enableNVMeDiscovery,
 	})
 	if err != nil {
 		klog.Fatalf("Failed to create driver: %v", err)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,15 +20,16 @@ import (
 
 // Config contains the configuration for the driver.
 type Config struct {
-	DriverName    string
-	Version       string
-	NodeID        string
-	Endpoint      string
-	APIURL        string
-	APIKey        string
-	MetricsAddr   string // Address to expose Prometheus metrics (e.g., ":8080")
-	TestMode      bool   // Enable test mode for sanity tests (skips actual mounts)
-	SkipTLSVerify bool   // Skip TLS certificate verification (for self-signed certs)
+	DriverName          string
+	Version             string
+	NodeID              string
+	Endpoint            string
+	APIURL              string
+	APIKey              string
+	MetricsAddr         string // Address to expose Prometheus metrics (e.g., ":8080")
+	TestMode            bool   // Enable test mode for sanity tests (skips actual mounts)
+	SkipTLSVerify       bool   // Skip TLS certificate verification (for self-signed certs)
+	EnableNVMeDiscovery bool   // Run nvme discover before nvme connect (default: false)
 }
 
 // Driver is the TNS CSI driver.
@@ -74,7 +75,7 @@ func NewDriverWithClient(cfg Config, client tnsapi.ClientInterface) (*Driver, er
 	// Initialize CSI services
 	d.identity = NewIdentityService(cfg.DriverName, cfg.Version)
 	d.controller = NewControllerService(client, nodeRegistry)
-	d.node = NewNodeService(cfg.NodeID, client, cfg.TestMode, nodeRegistry)
+	d.node = NewNodeService(cfg.NodeID, client, cfg.TestMode, nodeRegistry, cfg.EnableNVMeDiscovery)
 
 	return d, nil
 }

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -35,19 +35,21 @@ const (
 // NodeService implements the CSI Node service.
 type NodeService struct {
 	csi.UnimplementedNodeServer
-	apiClient    tnsapi.ClientInterface
-	nodeRegistry *NodeRegistry
-	nodeID       string
-	testMode     bool // Test mode flag to skip actual mounts
+	apiClient       tnsapi.ClientInterface
+	nodeRegistry    *NodeRegistry
+	nodeID          string
+	testMode        bool // Test mode flag to skip actual mounts
+	enableDiscovery bool // Run nvme discover before nvme connect
 }
 
 // NewNodeService creates a new node service.
-func NewNodeService(nodeID string, apiClient tnsapi.ClientInterface, testMode bool, nodeRegistry *NodeRegistry) *NodeService {
+func NewNodeService(nodeID string, apiClient tnsapi.ClientInterface, testMode bool, nodeRegistry *NodeRegistry, enableDiscovery bool) *NodeService {
 	return &NodeService{
-		nodeID:       nodeID,
-		apiClient:    apiClient,
-		testMode:     testMode,
-		nodeRegistry: nodeRegistry,
+		nodeID:          nodeID,
+		apiClient:       apiClient,
+		testMode:        testMode,
+		nodeRegistry:    nodeRegistry,
+		enableDiscovery: enableDiscovery,
 	}
 }
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -26,7 +26,7 @@ func TestNewNodeService(t *testing.T) {
 	mockClient := &mockAPIClient{}
 	nodeID := "test-node-123"
 
-	service := NewNodeService(nodeID, mockClient, true, registry)
+	service := NewNodeService(nodeID, mockClient, true, registry, false)
 
 	// Use require pattern - fail immediately if nil.
 	requireNotNilNode(t, service, "NewNodeService returned nil")
@@ -43,7 +43,7 @@ func TestNewNodeService(t *testing.T) {
 }
 
 func TestNodeGetCapabilities(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 
 	resp, err := service.NodeGetCapabilities(context.Background(), nil)
 	if err != nil {
@@ -82,7 +82,7 @@ func TestNodeGetInfo(t *testing.T) {
 	t.Run("with registry", func(t *testing.T) {
 		registry := NewNodeRegistry()
 		nodeID := "test-node-456"
-		service := NewNodeService(nodeID, nil, true, registry)
+		service := NewNodeService(nodeID, nil, true, registry, false)
 
 		resp, err := service.NodeGetInfo(context.Background(), nil)
 		if err != nil {
@@ -104,7 +104,7 @@ func TestNodeGetInfo(t *testing.T) {
 
 	t.Run("without registry", func(t *testing.T) {
 		nodeID := "test-node-789"
-		service := NewNodeService(nodeID, nil, true, nil)
+		service := NewNodeService(nodeID, nil, true, nil, false)
 
 		resp, err := service.NodeGetInfo(context.Background(), nil)
 		if err != nil {
@@ -118,7 +118,7 @@ func TestNodeGetInfo(t *testing.T) {
 }
 
 func TestNodeStageVolume_Validation(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 	ctx := context.Background()
 
 	//nolint:govet // Field alignment not critical for test structs
@@ -210,7 +210,7 @@ func TestNodeStageVolume_Validation(t *testing.T) {
 }
 
 func TestNodeUnstageVolume_Validation(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 	ctx := context.Background()
 
 	//nolint:govet // Field alignment not critical for test structs
@@ -265,7 +265,7 @@ func TestNodeUnstageVolume_Validation(t *testing.T) {
 }
 
 func TestNodePublishVolume_Validation(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 	ctx := context.Background()
 
 	//nolint:govet // Field alignment not critical for test structs
@@ -358,7 +358,7 @@ func TestNodePublishVolume_Validation(t *testing.T) {
 }
 
 func TestNodeUnpublishVolume_Validation(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 	ctx := context.Background()
 
 	//nolint:govet // Field alignment not critical for test structs
@@ -425,7 +425,7 @@ func TestNodeUnpublishVolume_TestMode(t *testing.T) {
 		t.Fatalf("Failed to create target path: %v", mkdirErr)
 	}
 
-	service := NewNodeService("test-node", nil, true, nil) // testMode=true
+	service := NewNodeService("test-node", nil, true, nil, false) // testMode=true
 	ctx := context.Background()
 
 	resp, err := service.NodeUnpublishVolume(ctx, &csi.NodeUnpublishVolumeRequest{
@@ -447,7 +447,7 @@ func TestNodeUnpublishVolume_TestMode(t *testing.T) {
 }
 
 func TestNodeGetVolumeStats_Validation(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 	ctx := context.Background()
 
 	//nolint:govet // Field alignment not critical for test structs
@@ -518,7 +518,7 @@ func TestNodeGetVolumeStats_TestMode(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	service := NewNodeService("test-node", nil, true, nil) // testMode=true
+	service := NewNodeService("test-node", nil, true, nil, false) // testMode=true
 	ctx := context.Background()
 
 	resp, err := service.NodeGetVolumeStats(ctx, &csi.NodeGetVolumeStatsRequest{
@@ -561,7 +561,7 @@ func TestNodeGetVolumeStats_TestMode(t *testing.T) {
 }
 
 func TestNodeExpandVolume_Validation(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 	ctx := context.Background()
 
 	//nolint:govet // Field alignment not critical for test structs
@@ -632,7 +632,7 @@ func TestNodeExpandVolume_TestMode(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	service := NewNodeService("test-node", nil, true, nil) // testMode=true
+	service := NewNodeService("test-node", nil, true, nil, false) // testMode=true
 	ctx := context.Background()
 
 	requestedBytes := int64(5 * 1024 * 1024 * 1024) // 5GB
@@ -964,7 +964,7 @@ func TestExtractNVMeOFOptionKey(t *testing.T) {
 }
 
 func TestValidateNVMeOFParamsQueueParams(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil)
+	service := NewNodeService("test-node", nil, true, nil, false)
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Description
Hey love the project! Recently switched over to it and noticed a couple of issues when mass connecting ~70 volumes on my lab. Currently it seems to begin to cascade due to timeouts. I believe that the nvemt discover is resource heavy and single threaded so when it runs per volume it beings to fail requests which cascades. Currently I have to scale down the workloads by hand, and then scale up slowly. This seems to help. Needs more testing.  

## Type of Change
<!-- Mark relevant items with an 'x' -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test addition or update

## Motivation

Cascading failure when trying to connect or reconnect 50+ targets. Needed to handle cluster build events or restarting a nvmeof target. 

## Changes Made

Disable nvme discovery and add `enableNVMeDiscovery: false`

## Testing

Deployed and tested at home, please do the same.

**Test environment:**
- Kubernetes version: Talos
- TrueNAS version: 25.10
- Protocol tested: [ ] NFS [x] NVMe-oF [ ] Both

**Tests run:**
- [x] Unit tests (`make test`)
- [ ] Linting (`make lint`)
- [ ] Sanity tests
- [ ] Integration tests (manual or CI)

## Documentation
<!-- Have you updated relevant documentation? -->
- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)
- [ ] No documentation needed

## Checklist
<!-- Ensure all items are complete before requesting review -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Considerations
<!-- Any security implications of this change? -->
- [x] This PR does not introduce security vulnerabilities
- [x] No secrets or credentials are included in this PR
- [x] I have reviewed SECURITY.md and followed best practices

## Related Issues

## Additional Notes
