### PR TITLE
fix: Removes the default metrics port binding

### DIFF
--- a/cmd/tns-csi-driver/main.go
+++ b/cmd/tns-csi-driver/main.go
@@ -25,7 +25,7 @@ var (
 	driverName                = flag.String("driver-name", "tns.csi.io", "Name of the driver")
 	apiURL                    = flag.String("api-url", "", "Storage system API URL (e.g., ws://10.10.20.100/api/v2.0/websocket)")
 	apiKey                    = flag.String("api-key", "", "Storage system API key")
-	metricsAddr               = flag.String("metrics-addr", ":8080", "Address to expose Prometheus metrics")
+	metricsAddr               = flag.String("metrics-addr", "", "Address to expose Prometheus metrics")
 	skipTLSVerify             = flag.Bool("skip-tls-verify", false, "Skip TLS certificate verification (for self-signed certificates)")
 	showVersion               = flag.Bool("show-version", false, "Show version and exit")
 	debug                     = flag.Bool("debug", false, "Enable debug logging (equivalent to -v=4)")


### PR DESCRIPTION
## Description

Changes the default value of `--metrics-addr` from `:8080` to an empty string, disabling metrics exposure by default.

## Type of Change
<!-- Mark relevant items with an 'x' -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation
<!-- Why is this change needed? What problem does it solve? -->
The driver was binding to port `:8080` by default even when metrics were not needed, which could cause port conflicts in environments where that port is already in use or reserved like NodeLocal DNSCache RKE2. Metrics should be opt-in.

## Changes Made
<!-- List the key changes made in this PR -->
- Changed default value of `--metrics-addr` flag from `:8080` to `""` (empty string), so Prometheus metrics are not exposed unless explicitly configured

## Testing
<!-- Describe how you tested these changes -->

**Test environment:**
- Kubernetes version:
- TrueNAS version:
- Protocol tested: [ ] NFS [ ] NVMe-oF [ ] Both

**Tests run:**
- [x] Unit tests (`make test`)
- [x] Linting (`make lint`)
- [ ] Sanity tests
- [ ] Integration tests (manual or CI)

## Documentation
<!-- Have you updated relevant documentation? -->
- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)
- [x] No documentation needed

## Checklist
<!-- Ensure all items are complete before requesting review -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Considerations
<!-- Any security implications of this change? -->
- [x] This PR does not introduce security vulnerabilities
- [x] No secrets or credentials are included in this PR
- [x] I have reviewed SECURITY.md and followed best practices

## Related Issues
<!-- Link any related issues here -->
Fixes #
Related to #

## Additional Notes
<!-- Any additional information reviewers should know -->
Users who rely on the default metrics endpoint will need to explicitly pass `--metrics-addr=:8080` (or another address) to re-enable it.