### PR TITLE
Support reading CSI driver API key from a file

### DIFF
--- a/cmd/tns-csi-driver/main.go
+++ b/cmd/tns-csi-driver/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/fenio/tns-csi/pkg/driver"
 	"github.com/fenio/tns-csi/pkg/metrics"
@@ -25,6 +26,7 @@ var (
 	driverName                = flag.String("driver-name", "tns.csi.io", "Name of the driver")
 	apiURL                    = flag.String("api-url", "", "Storage system API URL (e.g., ws://10.10.20.100/api/v2.0/websocket)")
 	apiKey                    = flag.String("api-key", "", "Storage system API key")
+	apiKeyFile                = flag.String("api-key-file", "", "Path to file containing the storage system API key")
 	metricsAddr               = flag.String("metrics-addr", ":8080", "Address to expose Prometheus metrics")
 	skipTLSVerify             = flag.Bool("skip-tls-verify", false, "Skip TLS certificate verification (for self-signed certificates)")
 	showVersion               = flag.Bool("show-version", false, "Show version and exit")
@@ -64,7 +66,11 @@ func main() {
 		klog.Fatal("Storage API URL must be provided")
 	}
 
-	if *apiKey == "" {
+	resolvedAPIKey, err := loadAPIKey(*apiKey, *apiKeyFile)
+	if err != nil {
+		klog.Fatalf("Storage API key: %v", err)
+	}
+	if resolvedAPIKey == "" {
 		klog.Fatal("Storage API key must be provided")
 	}
 
@@ -81,7 +87,7 @@ func main() {
 		NodeID:                    *nodeID,
 		Endpoint:                  *endpoint,
 		APIURL:                    *apiURL,
-		APIKey:                    *apiKey,
+		APIKey:                    resolvedAPIKey,
 		MetricsAddr:               *metricsAddr,
 		SkipTLSVerify:             *skipTLSVerify,
 		EnableNVMeDiscovery:       *enableNVMeDiscovery,
@@ -97,4 +103,22 @@ func main() {
 	if err := drv.Run(); err != nil {
 		klog.Fatalf("Failed to run driver: %v", err)
 	}
+}
+
+func loadAPIKey(value, filePath string) (string, error) {
+	if strings.TrimSpace(filePath) == "" {
+		return strings.TrimSpace(value), nil
+	}
+
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", filePath, err)
+	}
+
+	key := strings.TrimSpace(string(contents))
+	if key == "" {
+		return "", fmt.Errorf("%s is empty", filePath)
+	}
+
+	return key, nil
 }

--- a/cmd/tns-csi-driver/main_test.go
+++ b/cmd/tns-csi-driver/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAPIKeyFromFlag(t *testing.T) {
+	key, err := loadAPIKey("  from-flag\n", "")
+	if err != nil {
+		t.Fatalf("loadAPIKey returned error: %v", err)
+	}
+	if key != "from-flag" {
+		t.Fatalf("loadAPIKey returned %q, want trimmed flag value", key)
+	}
+}
+
+func TestLoadAPIKeyFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-key")
+	if err := os.WriteFile(path, []byte("\nfrom-file\n"), 0o600); err != nil {
+		t.Fatalf("write api key file: %v", err)
+	}
+
+	key, err := loadAPIKey("from-flag", path)
+	if err != nil {
+		t.Fatalf("loadAPIKey returned error: %v", err)
+	}
+	if key != "from-file" {
+		t.Fatalf("loadAPIKey returned %q, want file value to take precedence", key)
+	}
+}
+
+func TestLoadAPIKeyFromEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api-key")
+	if err := os.WriteFile(path, []byte("\n\t"), 0o600); err != nil {
+		t.Fatalf("write api key file: %v", err)
+	}
+
+	if _, err := loadAPIKey("", path); err == nil {
+		t.Fatal("loadAPIKey returned nil error for empty file")
+	}
+}
+
+func TestLoadAPIKeyFromMissingFile(t *testing.T) {
+	if _, err := loadAPIKey("", filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("loadAPIKey returned nil error for missing file")
+	}
+}


### PR DESCRIPTION
Adds a `--api-key-file` option for the CSI driver so Kubernetes deployments can mount the API key from a Secret volume instead of expanding it into process arguments.\n\nThis keeps the existing `--api-key` behavior for backward compatibility and gives file input precedence when both are set.\n\nValidation: `go test ./cmd/tns-csi-driver`.