### PR TITLE
test(driver): make getNVMeControllerState test host-independent

### DIFF
--- a/pkg/driver/node_health.go
+++ b/pkg/driver/node_health.go
@@ -23,6 +23,11 @@ var (
 	errISCSIStateUnknown = errors.New("could not determine iSCSI session state")
 )
 
+// sysClassNVMePath is the sysfs directory exposing NVMe controllers.
+// It is a variable so tests can point it at a controlled directory instead
+// of depending on the NVMe devices present on the host running the tests.
+var sysClassNVMePath = "/sys/class/nvme"
+
 // VolumeHealth represents the health status of a volume.
 type VolumeHealth struct {
 	Message  string
@@ -311,7 +316,7 @@ func getNVMeControllerState(devicePath string) (string, error) {
 	}
 
 	// Read state from /sys/class/nvme/<ctrl>/state
-	statePath := "/sys/class/nvme/" + ctrlName + "/state"
+	statePath := filepath.Join(sysClassNVMePath, ctrlName, "state")
 	data, err := os.ReadFile(statePath) //nolint:gosec // path is constructed from device name
 	if err != nil {
 		return "", fmt.Errorf("failed to read NVMe state: %w", err)

--- a/pkg/driver/node_health_test.go
+++ b/pkg/driver/node_health_test.go
@@ -1,6 +1,8 @@
 package driver
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -117,9 +119,24 @@ func TestCheckBasicHealth(t *testing.T) {
 }
 
 func TestGetNVMeControllerState(t *testing.T) {
+	// Point the sysfs lookup at a controlled directory so the test does not
+	// depend on which NVMe devices happen to be present on the host runner.
+	sysRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sysRoot, "nvme0"), 0o755); err != nil {
+		t.Fatalf("failed to set up fake sysfs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sysRoot, "nvme0", "state"), []byte("live\n"), 0o600); err != nil {
+		t.Fatalf("failed to write fake state: %v", err)
+	}
+
+	origPath := sysClassNVMePath
+	sysClassNVMePath = sysRoot
+	t.Cleanup(func() { sysClassNVMePath = origPath })
+
 	tests := []struct {
 		name       string
 		devicePath string
+		wantState  string
 		wantErr    bool
 	}{
 		{
@@ -128,20 +145,33 @@ func TestGetNVMeControllerState(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "nvme device - likely not present",
+			name:       "nvme device - controller present",
 			devicePath: "/dev/nvme0n1",
-			wantErr:    true, // Will fail on most test systems without NVMe
+			wantState:  "live",
+		},
+		{
+			name:       "nvme device - controller absent",
+			devicePath: "/dev/nvme9n1",
+			wantErr:    true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getNVMeControllerState(tt.devicePath)
-			if tt.wantErr && err == nil {
-				t.Errorf("getNVMeControllerState(%q) expected error, got nil", tt.devicePath)
+			state, err := getNVMeControllerState(tt.devicePath)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("getNVMeControllerState(%q) expected error, got nil", tt.devicePath)
+				}
+				return
 			}
-			// If we don't expect an error but get one, that's okay - the device may not exist
-			// This test is mainly to ensure the function doesn't panic
+			if err != nil {
+				t.Errorf("getNVMeControllerState(%q) unexpected error: %v", tt.devicePath, err)
+				return
+			}
+			if state != tt.wantState {
+				t.Errorf("getNVMeControllerState(%q) = %q, want %q", tt.devicePath, state, tt.wantState)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`TestGetNVMeControllerState/nvme_device_-_likely_not_present` asserted that querying `/dev/nvme0n1` returns an error, assuming the test host has no NVMe controller in sysfs. On CI runners that *do* have `/sys/class/nvme/nvme0/state`, the read succeeds and the function returns `nil` — failing the test. This is what broke Unit Tests on #178 (unrelated to that PR's Alpine bump).

## Fix

- Inject the sysfs root via a package var `sysClassNVMePath` (default `/sys/class/nvme`).
- The test now points it at a `t.TempDir()` with a fake `nvme0/state` file, so it no longer depends on host hardware.
- Coverage improves: now exercises non-nvme (error), controller **present** (returns `live`), and controller **absent** (error) — the old test never hit the success path.

```
--- PASS: TestGetNVMeControllerState (0.00s)
    --- PASS: .../non-nvme_device
    --- PASS: .../nvme_device_-_controller_present
    --- PASS: .../nvme_device_-_controller_absent
```