### PR TITLE
fix(tnsapi): re-authenticate when session is lost on a live connection

### DIFF
--- a/pkg/tnsapi/client.go
+++ b/pkg/tnsapi/client.go
@@ -24,6 +24,10 @@ import (
 const (
 	methodAuthLoginWithAPIKey = "auth.login_with_api_key" //nolint:gosec // API method name, not a credential
 
+	// errNameNotAuthenticated is reported by the storage API when the
+	// WebSocket session is not (or no longer) authenticated.
+	errNameNotAuthenticated = "ENOTAUTHENTICATED"
+
 	filterFieldName = "name"
 	filterFieldPath = "path"
 
@@ -89,6 +93,12 @@ type Client struct {
 	closed        bool
 	reconnecting  bool
 	skipTLSVerify bool // Skip TLS certificate verification
+
+	// reauthMu serializes session re-authentication after ENOTAUTHENTICATED;
+	// lastReauthAt lets concurrent failing calls reuse a just-completed re-auth
+	// instead of each performing its own.
+	reauthMu     sync.Mutex
+	lastReauthAt time.Time
 }
 
 // Request represents a storage API WebSocket request (JSON-RPC 2.0 format).
@@ -423,6 +433,44 @@ func (c *Client) authenticateDirect() error {
 	return nil
 }
 
+// isSessionAuthError reports whether err is an ENOTAUTHENTICATED error from
+// the storage API — the WebSocket session lost its authentication while the
+// connection itself stayed alive (observed after storage middleware restarts:
+// protocol-level pings keep succeeding, so reconnect() never fires, yet every
+// RPC fails). Unlike isAuthenticationError (permanent failures such as an
+// invalid API key), this condition is recoverable by re-authenticating on the
+// live connection.
+func isSessionAuthError(err error) bool {
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.ErrorName == errNameNotAuthenticated {
+		return true
+	}
+	return apiErr.Data != nil && apiErr.Data.ErrorName == errNameNotAuthenticated
+}
+
+// reauthenticate restores session authentication on the live connection after
+// an ENOTAUTHENTICATED response. Serialized so that many concurrent calls
+// failing at once trigger a single auth.login_with_api_key: callers that
+// arrive right after a completed re-authentication reuse its result.
+func (c *Client) reauthenticate() error {
+	c.reauthMu.Lock()
+	defer c.reauthMu.Unlock()
+
+	// Another caller has just re-authenticated this session — reuse it.
+	if time.Since(c.lastReauthAt) < time.Second {
+		return nil
+	}
+
+	if err := c.authenticate(); err != nil {
+		return err
+	}
+	c.lastReauthAt = time.Now()
+	return nil
+}
+
 // isConnectionError checks if the error is a connection-related error that should trigger a retry.
 func isConnectionError(err error) bool {
 	if err == nil {
@@ -456,6 +504,21 @@ func (c *Client) Call(ctx context.Context, method string, params []interface{}, 
 		}
 
 		lastErr = err
+
+		// Session-level auth loss: the storage system dropped our session
+		// without closing the WebSocket, so the connection looks healthy and
+		// reconnect() never fires — without re-authentication every call
+		// would fail with ENOTAUTHENTICATED forever. Re-authenticate on the
+		// live connection and retry. The auth call itself is excluded to
+		// avoid recursion.
+		if method != methodAuthLoginWithAPIKey && isSessionAuthError(err) {
+			klog.Warningf("Request %s failed with %s on a live connection (attempt %d/%d), re-authenticating...",
+				method, errNameNotAuthenticated, attempt, maxRetries)
+			if raErr := c.reauthenticate(); raErr != nil {
+				return fmt.Errorf("re-authentication after %s failed: %w", errNameNotAuthenticated, raErr)
+			}
+			continue
+		}
 
 		// Check if this is a retryable connection error
 		if !isConnectionError(err) {

--- a/pkg/tnsapi/client_test.go
+++ b/pkg/tnsapi/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -878,5 +879,200 @@ func TestQueryPool(t *testing.T) {
 				t.Errorf("Pool free = %d, want %d", pool.Properties.Free.Parsed, tt.wantFree)
 			}
 		})
+	}
+}
+
+// enotauthenticatedError mimics the error the storage API returns when the
+// WebSocket session has lost its authentication (e.g. middleware restart on
+// the storage side that keeps TCP connections alive).
+func enotauthenticatedError() *Error {
+	return &Error{
+		Code:    -32001,
+		Message: "Method call error",
+		Data: &ErrorData{
+			Error:     207,
+			ErrorName: "ENOTAUTHENTICATED",
+			Reason:    "[ENOTAUTHENTICATED] Not authenticated",
+		},
+	}
+}
+
+func TestIsSessionAuthError(t *testing.T) {
+	tests := []struct {
+		err  error
+		name string
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "connection error", err: ErrConnectionClosed, want: false},
+		{name: "ENOTAUTHENTICATED in data", err: enotauthenticatedError(), want: true},
+		{
+			name: "ENOTAUTHENTICATED in top-level errname",
+			err:  &Error{ErrorName: "ENOTAUTHENTICATED", Reason: "[ENOTAUTHENTICATED] Not authenticated"},
+			want: true,
+		},
+		{
+			name: "wrapped ENOTAUTHENTICATED",
+			err:  fmt.Errorf("call failed: %w", enotauthenticatedError()),
+			want: true,
+		},
+		{
+			name: "other API error",
+			err:  &Error{Code: 401, Message: "invalid API key"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSessionAuthError(tt.err); got != tt.want {
+				t.Errorf("isSessionAuthError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCallReauthenticatesOnSessionAuthLoss reproduces the session-loss
+// scenario: the server starts answering ENOTAUTHENTICATED on a perfectly
+// healthy connection. Call() must re-authenticate on the live socket and
+// retry the original request instead of failing forever.
+func TestCallReauthenticatesOnSessionAuthLoss(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authCalls := 0
+	dataCalls := 0
+
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+
+			var req Request
+			if err := json.Unmarshal(message, &req); err != nil {
+				continue
+			}
+
+			resp := Response{ID: req.ID}
+
+			mu.Lock()
+			switch req.Method {
+			case "auth.login_with_api_key":
+				authCalls++
+				resp.Result = json.RawMessage(`true`)
+			default:
+				dataCalls++
+				if dataCalls == 1 {
+					// Session silently dropped server-side: the connection
+					// stays open, but calls are no longer authenticated.
+					resp.Error = enotauthenticatedError()
+				} else {
+					resp.Result = json.RawMessage(`true`)
+				}
+			}
+			mu.Unlock()
+
+			respBytes, err := json.Marshal(resp)
+			if err == nil {
+				//nolint:errcheck,gosec // test server write
+				conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var result bool
+	if err := client.Call(ctx, "test.method", nil, &result); err != nil {
+		t.Fatalf("Call() after session auth loss should recover, got error: %v", err)
+	}
+	if !result {
+		t.Error("Call() result = false, want true")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// initial NewClient auth + one re-auth triggered by ENOTAUTHENTICATED
+	if authCalls != 2 {
+		t.Errorf("auth.login_with_api_key calls = %d, want 2 (initial + re-auth)", authCalls)
+	}
+	if dataCalls != 2 {
+		t.Errorf("data calls = %d, want 2 (failed + retried)", dataCalls)
+	}
+}
+
+// TestAuthCallDoesNotRecurseOnSessionAuthLoss guards against infinite
+// recursion: if auth.login_with_api_key itself fails with ENOTAUTHENTICATED,
+// Call() must NOT trigger another re-authentication.
+func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authCalls := 0
+
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+
+			var req Request
+			if err := json.Unmarshal(message, &req); err != nil {
+				continue
+			}
+
+			resp := Response{ID: req.ID}
+
+			mu.Lock()
+			authCalls++
+			if authCalls == 1 {
+				// Let NewClient succeed
+				resp.Result = json.RawMessage(`true`)
+			} else {
+				resp.Error = enotauthenticatedError()
+			}
+			mu.Unlock()
+
+			respBytes, err := json.Marshal(resp)
+			if err == nil {
+				//nolint:errcheck,gosec // test server write
+				conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	// Force lastReauthAt out of the reuse window and re-authenticate: the
+	// auth call fails with ENOTAUTHENTICATED and must surface the error
+	// without recursing.
+	if err := client.reauthenticate(); err == nil {
+		t.Fatal("reauthenticate() should fail when auth itself gets ENOTAUTHENTICATED")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// initial NewClient auth + exactly ONE failed re-auth attempt
+	if authCalls != 2 {
+		t.Errorf("auth.login_with_api_key calls = %d, want 2 (no recursion)", authCalls)
 	}
 }


### PR DESCRIPTION
## Problem

TrueNAS can drop WebSocket sessions without closing the TCP connection (e.g. when the middleware restarts). The client then ends up permanently broken: protocol-level pings keep succeeding, so `reconnect()` never fires, yet every RPC fails with `ENOTAUTHENTICATED` (207) until the process is restarted — while the same API key authenticates fine from a fresh connection.

In a CSI deployment this means provisioning silently stops working (every `CreateVolume` fails) even though the controller pod looks perfectly healthy, and the only recovery is a manual pod restart.

## Fix

Treat `ENOTAUTHENTICATED` as a recoverable session-level condition in `Call()`:

- `isSessionAuthError()` detects it via `errors.As` on `*Error` (both top-level `errname` and nested `data.errname`). This is distinct from the existing `isAuthenticationError()`, which covers permanent failures such as a revoked/invalid API key.
- `reauthenticate()` performs `auth.login_with_api_key` on the live connection. It is serialized: a burst of concurrent failing calls triggers a single re-authentication, late arrivals reuse the just-completed one.
- The retry loop in `Call()` re-authenticates and retries the original request within the existing retry budget. The auth call itself is excluded from this path to avoid recursion.

## Testing

- `TestIsSessionAuthError` — detection matrix (top-level/nested `errname`, wrapped errors, unrelated errors).
- `TestCallReauthenticatesOnSessionAuthLoss` — full recovery against the mock WS server: the server starts answering `ENOTAUTHENTICATED` on a healthy connection; the client re-authenticates exactly once and completes the original call.
- `TestAuthCallDoesNotRecurseOnSessionAuthLoss` — recursion guard when the auth call itself gets `ENOTAUTHENTICATED`.
- Full `pkg/tnsapi` suite passes (`go build ./... && go vet && go test`).