### PR TITLE
fix(nvmeof): verify disconnect cleanup

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -36,12 +37,15 @@ const (
 // NodeService implements the CSI Node service.
 type NodeService struct {
 	csi.UnimplementedNodeServer
-	apiClient       tnsapi.ClientInterface
-	nodeRegistry    *NodeRegistry
-	nvmeConnectSem  chan struct{}
-	nodeID          string
-	testMode        bool
-	enableDiscovery bool
+	apiClient      tnsapi.ClientInterface
+	nodeRegistry   *NodeRegistry
+	nvmeConnectSem chan struct{}
+	// disconnectNVMeOFFn is overridden by focused node-service tests.
+	disconnectNVMeOFFn func(context.Context, string) error
+	nodeID             string
+	nvmeLifecycleMu    sync.Mutex
+	testMode           bool
+	enableDiscovery    bool
 }
 
 // NewNodeService creates a new node service.
@@ -211,6 +215,13 @@ func (s *NodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 // detectProtocolFromStagingPath attempts to detect the protocol from the staging path.
 // It checks the mount source to determine if it's a block device (NVMe-oF/iSCSI) or NFS mount.
 func (s *NodeService) detectProtocolFromStagingPath(ctx context.Context, stagingPath string) string {
+	if nqn, err := readNVMeStagingNQN(stagingPath); err != nil {
+		klog.Warningf("NVMe-oF staging metadata for %s is invalid: %v", stagingPath, err)
+		return ProtocolNVMeOF
+	} else if nqn != "" {
+		return ProtocolNVMeOF
+	}
+
 	// Check if the path exists first
 	if _, err := os.Stat(stagingPath); os.IsNotExist(err) {
 		// Path doesn't exist, default to NFS (most common case for cleanup)

--- a/pkg/driver/node_nvmeof.go
+++ b/pkg/driver/node_nvmeof.go
@@ -32,6 +32,7 @@ var (
 	ErrNVMeEmptyNQN                = errors.New("empty NQN in sysfs")
 	ErrNVMeNotNVMeDevice           = errors.New("not an NVMe device")
 	ErrNVMeNonNVMeStagingDevice    = errors.New("staging path resolved to non-NVMe device")
+	ErrNVMeCleanupTimeout          = errors.New("timeout waiting for NVMe-oF controller cleanup")
 )
 
 // NVMe subsystem states.
@@ -42,6 +43,8 @@ const (
 // defaultNVMeOFMountOptions are sensible defaults for NVMe-oF filesystem mounts.
 // These are merged with user-specified mount options from StorageClass.
 var defaultNVMeOFMountOptions = []string{zfsNoatime}
+
+const nvmeStagingMetadataSuffix = ".tns-csi-nvmeof"
 
 // nvmeOFConnectionParams holds validated NVMe-oF connection parameters.
 // With independent subsystems per volume, NSID is always 1.
@@ -65,6 +68,9 @@ func (s *NodeService) stageNVMeOFVolume(ctx context.Context, req *csi.NodeStageV
 	params, err := s.validateNVMeOFParams(volumeContext)
 	if err != nil {
 		return nil, err
+	}
+	if err := writeNVMeStagingNQN(stagingTargetPath, params.nqn); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to persist NVMe-oF staging metadata: %v", err)
 	}
 
 	isBlockVolume := volumeCapability.GetBlock() != nil
@@ -400,6 +406,23 @@ func (s *NodeService) unstageNVMeOFVolume(ctx context.Context, req *csi.NodeUnst
 			klog.V(4).Infof("Derived NVMe-oF NQN from staging path %s: %s", stagingTargetPath, nqn)
 		}
 	}
+	if nqn == "" {
+		// A missing path after a completed unstage is an idempotent success. If the
+		// path still exists, losing its NQN is unsafe because a live session may leak.
+		if _, statErr := os.Lstat(stagingTargetPath); os.IsNotExist(statErr) {
+			klog.V(4).Infof("Staging path %s no longer exists; volume %s is already unstaged", stagingTargetPath, volumeID)
+			return &csi.NodeUnstageVolumeResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Internal,
+			"cannot determine NQN for NVMe-oF volume %s at staging path %s; refusing to report successful unstage",
+			volumeID, stagingTargetPath)
+	}
+
+	// CSI does not include VolumeContext in NodeUnstageVolume retries. Persist the
+	// NQN before unmounting so a failed disconnect cannot be retried as NFS.
+	if err := writeNVMeStagingNQN(stagingTargetPath, nqn); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to persist NVMe-oF staging metadata before unmount: %v", err)
+	}
 
 	// Check if mounted and unmount if necessary
 	mounted, err := mount.IsMounted(ctx, stagingTargetPath)
@@ -414,25 +437,27 @@ func (s *NodeService) unstageNVMeOFVolume(ctx context.Context, req *csi.NodeUnst
 		}
 	}
 
-	// If we don't have NQN, we can't disconnect
-	if nqn == "" {
-		klog.Warningf("Cannot determine NQN for volume %s - skipping NVMe-oF disconnect", volumeID)
-		return &csi.NodeUnstageVolumeResponse{}, nil
-	}
-
 	// With independent subsystems, always disconnect (no shared subsystem to worry about)
 	klog.V(4).Infof("Disconnecting NVMe-oF subsystem for volume %s: NQN=%s", volumeID, nqn)
 	if err := s.disconnectNVMeOF(ctx, nqn); err != nil {
-		klog.Warningf("Failed to disconnect NVMe-oF device (continuing anyway): %v", err)
-	} else {
-		klog.V(4).Infof("Disconnected from NVMe-oF target: %s", nqn)
+		return nil, status.Errorf(codes.Internal, "failed to disconnect NVMe-oF volume %s (NQN %s): %v", volumeID, nqn, err)
 	}
+	if err := removeNVMeStagingNQN(stagingTargetPath); err != nil {
+		return nil, status.Errorf(codes.Internal, "disconnected NVMe-oF volume %s but failed to remove staging metadata: %v", volumeID, err)
+	}
+	klog.Infof("Disconnected NVMe-oF volume %s from target %s", volumeID, nqn)
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
 // deriveNQNFromStagingPath derives the NVMe-oF NQN from Linux mount/device metadata.
 func (s *NodeService) deriveNQNFromStagingPath(ctx context.Context, stagingTargetPath string) (string, error) {
+	if nqn, err := readNVMeStagingNQN(stagingTargetPath); err == nil && nqn != "" {
+		return nqn, nil
+	} else if err != nil {
+		klog.Warningf("Failed to read NVMe-oF staging metadata for %s: %v; falling back to device metadata", stagingTargetPath, err)
+	}
+
 	devicePath, err := s.getStagedNVMeDevicePath(ctx, stagingTargetPath)
 	if err != nil {
 		return "", err
@@ -455,6 +480,43 @@ func (s *NodeService) deriveNQNFromStagingPath(ctx context.Context, stagingTarge
 		return "", fmt.Errorf("%s: %w", nqnPath, ErrNVMeEmptyNQN)
 	}
 	return nqn, nil
+}
+
+func nvmeStagingMetadataPath(stagingTargetPath string) string {
+	return stagingTargetPath + nvmeStagingMetadataSuffix
+}
+
+func writeNVMeStagingNQN(stagingTargetPath, nqn string) error {
+	if strings.TrimSpace(nqn) == "" {
+		return ErrNVMeEmptyNQN
+	}
+	if err := os.MkdirAll(filepath.Dir(stagingTargetPath), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(nvmeStagingMetadataPath(stagingTargetPath), []byte(nqn+"\n"), 0o600)
+}
+
+func readNVMeStagingNQN(stagingTargetPath string) (string, error) {
+	data, err := os.ReadFile(nvmeStagingMetadataPath(stagingTargetPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	nqn := strings.TrimSpace(string(data))
+	if nqn == "" {
+		return "", ErrNVMeEmptyNQN
+	}
+	return nqn, nil
+}
+
+func removeNVMeStagingNQN(stagingTargetPath string) error {
+	err := os.Remove(nvmeStagingMetadataPath(stagingTargetPath))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 // getStagedNVMeDevicePath resolves the NVMe device backing a staging path.

--- a/pkg/driver/node_nvmeof_device.go
+++ b/pkg/driver/node_nvmeof_device.go
@@ -3,7 +3,9 @@ package driver
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,6 +17,11 @@ import (
 // This handles transient failures when TrueNAS has just created a new subsystem
 // (e.g., for snapshot-restored volumes) but it's not yet fully ready for connections.
 func (s *NodeService) connectNVMeOFTarget(ctx context.Context, params *nvmeOFConnectionParams) error {
+	// Connect and disconnect both mutate the kernel NVMe controller registry.
+	// Serializing those transitions prevents teardown from racing registration.
+	s.nvmeLifecycleMu.Lock()
+	defer s.nvmeLifecycleMu.Unlock()
+
 	if s.enableDiscovery {
 		// Discover the NVMe-oF target
 		klog.V(4).Infof("Discovering NVMe-oF target at %s:%s", params.server, params.port)
@@ -151,6 +158,14 @@ func (s *NodeService) checkNVMeCLI(ctx context.Context) error {
 
 // disconnectNVMeOF disconnects from an NVMe-oF target and waits for device cleanup.
 func (s *NodeService) disconnectNVMeOF(ctx context.Context, nqn string) error {
+	if s.disconnectNVMeOFFn != nil {
+		return s.disconnectNVMeOFFn(ctx, nqn)
+	}
+
+	// Keep controller teardown mutually exclusive with controller registration.
+	s.nvmeLifecycleMu.Lock()
+	defer s.nvmeLifecycleMu.Unlock()
+
 	klog.V(4).Infof("Disconnecting from NVMe-oF target: %s", nqn)
 
 	disconnectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -159,28 +174,104 @@ func (s *NodeService) disconnectNVMeOF(ctx context.Context, nqn string) error {
 	cmd := exec.CommandContext(disconnectCtx, "nvme", "disconnect", "-n", nqn)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// Check if already disconnected
-		if strings.Contains(string(output), "No subsystems") || strings.Contains(string(output), "not found") {
-			klog.V(4).Infof("NVMe device already disconnected")
+		// nvme-cli error text varies by version. Verify the kernel state instead
+		// of relying on messages such as "No subsystems" for idempotency.
+		present, verifyErr := nvmeNQNPresent(nvmeSysClassPath, nqn)
+		if verifyErr != nil {
+			return fmt.Errorf("failed to disconnect NVMe-oF device: %w, output: %s; cleanup verification failed: %w", err, string(output), verifyErr)
+		}
+		if present {
+			return fmt.Errorf("failed to disconnect NVMe-oF device: %w, output: %s", err, string(output))
+		}
+		klog.V(4).Infof("NVMe-oF target %s is already absent after disconnect returned: %v", nqn, err)
+	} else {
+		klog.V(4).Infof("Successfully requested disconnect from NVMe-oF target")
+	}
+
+	// nvme disconnect returning does not guarantee that sysfs and device nodes
+	// have been removed. Do not let kubelet reuse the volume until the exact NQN
+	// is absent from the kernel controller registry.
+	if err := waitForNVMeNQNRemoval(ctx, nqn, 30*time.Second); err != nil {
+		return err
+	}
+
+	klog.V(4).Infof("Kernel cleanup complete for NVMe-oF target %s", nqn)
+	return nil
+}
+
+const nvmeSysClassPath = "/sys/class/nvme"
+
+func waitForNVMeNQNRemoval(ctx context.Context, nqn string, timeout time.Duration) error {
+	return waitForNVMeNQNRemovalAt(ctx, nvmeSysClassPath, nqn, timeout, 250*time.Millisecond)
+}
+
+func waitForNVMeNQNRemovalAt(ctx context.Context, sysClassPath, nqn string, timeout, pollInterval time.Duration) error {
+	cleanupCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		present, err := nvmeNQNPresent(sysClassPath, nqn)
+		if err != nil {
+			return fmt.Errorf("failed to verify NVMe-oF cleanup for NQN %s: %w", nqn, err)
+		}
+		if !present {
 			return nil
 		}
-		return fmt.Errorf("failed to disconnect NVMe-oF device: %w, output: %s", err, string(output))
+
+		select {
+		case <-time.After(pollInterval):
+		case <-cleanupCtx.Done():
+			return fmt.Errorf("%w for NQN %s: %w", ErrNVMeCleanupTimeout, nqn, cleanupCtx.Err())
+		}
+	}
+}
+
+// nvmeNQNPresent checks exact subsystem identities rather than relying on
+// ephemeral controller numbers such as nvme4.
+func nvmeNQNPresent(sysClassPath, nqn string) (bool, error) {
+	entries, err := os.ReadDir(sysClassPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
 	}
 
-	klog.V(4).Infof("Successfully disconnected from NVMe-oF target")
+	for _, entry := range entries {
+		name := entry.Name()
+		if !isNVMeControllerName(name) {
+			continue
+		}
 
-	// Wait for kernel to cleanup device nodes
-	const deviceCleanupDelay = 1 * time.Second
-	klog.V(4).Infof("Waiting %v for kernel to cleanup NVMe devices after disconnect", deviceCleanupDelay)
-	select {
-	case <-time.After(deviceCleanupDelay):
-		klog.V(4).Infof("Device cleanup delay complete")
-	case <-ctx.Done():
-		klog.Warningf("Context canceled during device cleanup delay: %v", ctx.Err())
-		return ctx.Err()
+		data, readErr := os.ReadFile(filepath.Join(sysClassPath, name, "subsysnqn")) //nolint:gosec // fixed sysfs file below a validated controller name
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				continue
+			}
+			return false, readErr
+		}
+		if strings.TrimSpace(string(data)) == nqn {
+			return true, nil
+		}
 	}
 
-	return nil
+	return false, nil
+}
+
+func isNVMeControllerName(name string) bool {
+	if !strings.HasPrefix(name, "nvme") {
+		return false
+	}
+	suffix := strings.TrimPrefix(name, "nvme")
+	if suffix == "" {
+		return false
+	}
+	for _, char := range suffix {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // rescanNVMeNamespace rescans an NVMe namespace to ensure the kernel has fresh device data.

--- a/pkg/driver/node_nvmeof_discovery.go
+++ b/pkg/driver/node_nvmeof_discovery.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -27,36 +28,52 @@ func getSubsystemState(ctx context.Context, nqn string) string {
 		return ""
 	}
 
-	// Parse the JSON to find the subsystem and its state
-	// Look for the NQN and then find the State field in the same subsystem block
-	lines := strings.Split(string(output), "\n")
-	foundNQN := false
-	for _, line := range lines {
-		if strings.Contains(line, nqn) {
-			foundNQN = true
-		}
-		// Once we found the NQN, look for the State field
-		if foundNQN && strings.Contains(line, "\"State\"") {
-			// Extract state value: "State" : "live"
-			parts := strings.Split(line, "\"")
-			for i, part := range parts {
-				if part == "State" && i+2 < len(parts) {
-					state := strings.TrimSpace(parts[i+2])
-					klog.V(4).Infof("Subsystem %s state: %s", nqn, state)
-					return state
-				}
-			}
-		}
-		// Stop if we hit the next subsystem (next NQN)
-		if foundNQN && strings.Contains(line, "\"NQN\"") && !strings.Contains(line, nqn) {
-			break
-		}
+	subsystem, parseErr := findNVMeSubsystem(output, nqn)
+	if parseErr != nil {
+		klog.V(4).Infof("Failed to parse nvme list-subsys output: %v", parseErr)
+		return ""
 	}
-
-	if foundNQN {
-		klog.V(4).Infof("Found NQN %s but could not extract state", nqn)
+	if subsystem != nil && len(subsystem.Paths) > 0 {
+		state := subsystem.Paths[0].State
+		klog.V(4).Infof("Subsystem %s state: %s", nqn, state)
+		return state
 	}
 	return ""
+}
+
+type nvmeListSubsystemsOutput struct {
+	Subsystems []nvmeListSubsystem `json:"Subsystems"`
+}
+
+type nvmeListSubsystem struct {
+	NQN          string         `json:"NQN"`
+	SubsystemNQN string         `json:"SubsystemNQN"`
+	Paths        []nvmeListPath `json:"Paths"`
+}
+
+type nvmeListPath struct {
+	Name  string `json:"Name"`
+	State string `json:"State"`
+}
+
+func (s nvmeListSubsystem) nqn() string {
+	if s.SubsystemNQN != "" {
+		return s.SubsystemNQN
+	}
+	return s.NQN
+}
+
+func findNVMeSubsystem(output []byte, nqn string) (*nvmeListSubsystem, error) {
+	var parsed nvmeListSubsystemsOutput
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		return nil, err
+	}
+	for i := range parsed.Subsystems {
+		if parsed.Subsystems[i].nqn() == nqn {
+			return &parsed.Subsystems[i], nil
+		}
+	}
+	return nil, nil //nolint:nilnil // nil means the exact NQN was not found
 }
 
 // waitForSubsystemLive waits for the NVMe subsystem to reach "live" state.
@@ -179,62 +196,16 @@ func (s *NodeService) runNVMeListSubsys(ctx context.Context) ([]byte, error) {
 // parseNVMeListSubsysOutputForNQN parses nvme list-subsys JSON output to find device path.
 // With independent subsystems, NSID is always 1.
 func (s *NodeService) parseNVMeListSubsysOutputForNQN(output []byte, nqn string) string {
-	lines := strings.Split(string(output), "\n")
-	foundNQN := false
-
-	for i, line := range lines {
-		if !strings.Contains(line, nqn) {
-			continue
-		}
-
-		foundNQN = true
-		devicePath := s.extractDevicePathFromLinesForNQN(lines, i, nqn)
-		if devicePath != "" {
+	subsystem, err := findNVMeSubsystem(output, nqn)
+	if err != nil || subsystem == nil {
+		return ""
+	}
+	for _, path := range subsystem.Paths {
+		if isNVMeControllerName(path.Name) {
+			devicePath := fmt.Sprintf("/dev/%sn1", path.Name)
+			klog.V(4).Infof("Found NVMe device from list-subsys: %s (controller: %s, NQN: %s)",
+				devicePath, path.Name, nqn)
 			return devicePath
-		}
-	}
-
-	if foundNQN {
-		klog.Warningf("Found NQN but could not extract device name, falling back to sysfs")
-	}
-	return ""
-}
-
-// extractDevicePathFromLinesForNQN searches for controller name in lines after the NQN line.
-// With independent subsystems, NSID is always 1.
-func (s *NodeService) extractDevicePathFromLinesForNQN(lines []string, startIdx int, nqn string) string {
-	// Look ahead for the "Name" field in the Paths section (up to 20 lines)
-	endIdx := startIdx + 20
-	if endIdx > len(lines) {
-		endIdx = len(lines)
-	}
-
-	for j := startIdx; j < endIdx; j++ {
-		if !strings.Contains(lines[j], "\"Name\"") || !strings.Contains(lines[j], "nvme") {
-			continue
-		}
-
-		// Extract controller name - format: "Name" : "nvme0"
-		parts := strings.Split(lines[j], "\"")
-		controllerName := s.extractControllerFromParts(parts)
-		if controllerName == "" {
-			continue
-		}
-
-		// With independent subsystems, NSID is always 1
-		devicePath := fmt.Sprintf("/dev/%sn1", controllerName)
-		klog.V(4).Infof("Found NVMe device from list-subsys: %s (controller: %s, NQN: %s)",
-			devicePath, controllerName, nqn)
-		return devicePath
-	}
-	return ""
-}
-
-// extractControllerFromParts extracts controller name from parsed JSON parts.
-func (s *NodeService) extractControllerFromParts(parts []string) string {
-	for k := range len(parts) - 1 {
-		if parts[k] == "Name" && k+2 < len(parts) {
-			return strings.TrimSpace(parts[k+2])
 		}
 	}
 	return ""
@@ -436,28 +407,13 @@ func (s *NodeService) findNVMeDeviceByNQNWithController(ctx context.Context, nqn
 
 // findControllerForNQN parses nvme list-subsys output to find the controller name for a given NQN.
 func (s *NodeService) findControllerForNQN(output, nqn string) string {
-	lines := strings.Split(output, "\n")
-	foundNQN := false
-
-	for i, line := range lines {
-		if strings.Contains(line, nqn) {
-			foundNQN = true
-		}
-		if foundNQN && strings.Contains(line, "\"Name\"") && strings.Contains(line, "nvme") {
-			// Extract controller name from "Name" : "nvme0"
-			parts := strings.Split(line, "\"")
-			for k := range len(parts) - 1 {
-				if parts[k] == "Name" && k+2 < len(parts) {
-					name := strings.TrimSpace(parts[k+2])
-					if strings.HasPrefix(name, "nvme") && !strings.Contains(name, "n") {
-						return name
-					}
-				}
-			}
-		}
-		// Reset if we've moved past this subsystem's section
-		if foundNQN && i > 0 && strings.Contains(line, "NQN") && !strings.Contains(line, nqn) {
-			foundNQN = false
+	subsystem, err := findNVMeSubsystem([]byte(output), nqn)
+	if err != nil || subsystem == nil {
+		return ""
+	}
+	for _, path := range subsystem.Paths {
+		if isNVMeControllerName(path.Name) {
+			return path.Name
 		}
 	}
 	return ""

--- a/pkg/driver/node_nvmeof_test.go
+++ b/pkg/driver/node_nvmeof_test.go
@@ -1,0 +1,189 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestParseNVMeListSubsysOutputUsesExactNQN(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	output := []byte(`{
+  "Subsystems": [
+    {
+      "SubsystemNQN": "nqn.2026-02.csi.tns:volume-longer",
+      "Paths": [{"Name": "nvme4", "State": "live"}]
+    },
+    {
+      "SubsystemNQN": "nqn.2026-02.csi.tns:volume",
+      "Paths": [{"Name": "nvme7", "State": "live"}]
+    }
+  ]
+}`)
+
+	const nqn = "nqn.2026-02.csi.tns:volume"
+	if got := service.parseNVMeListSubsysOutputForNQN(output, nqn); got != "/dev/nvme7n1" {
+		t.Fatalf("parseNVMeListSubsysOutputForNQN() = %q, want %q", got, "/dev/nvme7n1")
+	}
+	if got := service.findControllerForNQN(string(output), nqn); got != "nvme7" {
+		t.Fatalf("findControllerForNQN() = %q, want %q", got, "nvme7")
+	}
+}
+
+func TestParseNVMeListSubsysOutputSupportsNQNField(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	output := []byte(`{
+  "Subsystems": [{
+    "NQN": "nqn.2026-02.csi.tns:volume",
+    "Paths": [{"Name": "nvme2", "State": "live"}]
+  }]
+}`)
+
+	if got := service.parseNVMeListSubsysOutputForNQN(output, "nqn.2026-02.csi.tns:volume"); got != "/dev/nvme2n1" {
+		t.Fatalf("parseNVMeListSubsysOutputForNQN() = %q, want %q", got, "/dev/nvme2n1")
+	}
+}
+
+func TestNVMeNQNPresentUsesExactIdentity(t *testing.T) {
+	sysClassPath := t.TempDir()
+	writeTestSubsystemNQN(t, sysClassPath, "nvme4", "nqn.2026-02.csi.tns:volume-longer")
+	writeTestSubsystemNQN(t, sysClassPath, "nvme4n1", "nqn.2026-02.csi.tns:volume")
+	writeTestSubsystemNQN(t, sysClassPath, "nvme7", "nqn.2026-02.csi.tns:volume")
+
+	present, err := nvmeNQNPresent(sysClassPath, "nqn.2026-02.csi.tns:volume")
+	if err != nil {
+		t.Fatalf("nvmeNQNPresent() unexpected error: %v", err)
+	}
+	if !present {
+		t.Fatal("nvmeNQNPresent() = false, want true")
+	}
+
+	present, err = nvmeNQNPresent(sysClassPath, "nqn.2026-02.csi.tns:vol")
+	if err != nil {
+		t.Fatalf("nvmeNQNPresent() unexpected error: %v", err)
+	}
+	if present {
+		t.Fatal("nvmeNQNPresent() matched a partial NQN")
+	}
+}
+
+func TestWaitForNVMeNQNRemoval(t *testing.T) {
+	sysClassPath := t.TempDir()
+	nqnPath := writeTestSubsystemNQN(t, sysClassPath, "nvme4", "nqn.2026-02.csi.tns:volume")
+	removed := make(chan error, 1)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		removed <- os.Remove(nqnPath)
+	}()
+
+	err := waitForNVMeNQNRemovalAt(context.Background(), sysClassPath, "nqn.2026-02.csi.tns:volume", time.Second, 5*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForNVMeNQNRemovalAt() unexpected error: %v", err)
+	}
+	if removeErr := <-removed; removeErr != nil {
+		t.Fatalf("failed to remove test NQN: %v", removeErr)
+	}
+}
+
+func TestWaitForNVMeNQNRemovalTimesOut(t *testing.T) {
+	sysClassPath := t.TempDir()
+	writeTestSubsystemNQN(t, sysClassPath, "nvme4", "nqn.2026-02.csi.tns:volume")
+
+	err := waitForNVMeNQNRemovalAt(context.Background(), sysClassPath, "nqn.2026-02.csi.tns:volume", 20*time.Millisecond, 5*time.Millisecond)
+	if !errors.Is(err, ErrNVMeCleanupTimeout) {
+		t.Fatalf("waitForNVMeNQNRemovalAt() error = %v, want ErrNVMeCleanupTimeout", err)
+	}
+}
+
+func TestUnstageNVMeOFVolumeReturnsDisconnectFailure(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	disconnectErr := errors.New("disconnect failed")
+	service.disconnectNVMeOFFn = func(_ context.Context, _ string) error {
+		return disconnectErr
+	}
+
+	stagingPath := filepath.Join(t.TempDir(), "globalmount")
+	resp, err := service.unstageNVMeOFVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "tank/volumes/test-volume",
+		StagingTargetPath: stagingPath,
+	}, map[string]string{VolumeContextKeyNQN: "nqn.2026-02.csi.tns:volume"})
+	if resp != nil {
+		t.Fatalf("unstageNVMeOFVolume() response = %#v, want nil", resp)
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("unstageNVMeOFVolume() code = %s, want %s (error: %v)", status.Code(err), codes.Internal, err)
+	}
+	if got, readErr := readNVMeStagingNQN(stagingPath); readErr != nil || got != "nqn.2026-02.csi.tns:volume" {
+		t.Fatalf("staging metadata after failed disconnect = %q, %v", got, readErr)
+	}
+}
+
+func TestUnstageNVMeOFVolumeRejectsUnknownNQN(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	stagingPath := t.TempDir()
+
+	resp, err := service.unstageNVMeOFVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "tank/volumes/test-volume",
+		StagingTargetPath: stagingPath,
+	}, nil)
+	if resp != nil {
+		t.Fatalf("unstageNVMeOFVolume() response = %#v, want nil", resp)
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("unstageNVMeOFVolume() code = %s, want %s (error: %v)", status.Code(err), codes.Internal, err)
+	}
+}
+
+func TestNVMeStagingMetadataSupportsUnstageRetry(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	stagingPath := filepath.Join(t.TempDir(), "globalmount")
+	const nqn = "nqn.2026-02.csi.tns:volume"
+	if err := writeNVMeStagingNQN(stagingPath, nqn); err != nil {
+		t.Fatalf("writeNVMeStagingNQN() unexpected error: %v", err)
+	}
+
+	if got := service.detectProtocolFromStagingPath(context.Background(), stagingPath); got != ProtocolNVMeOF {
+		t.Fatalf("detectProtocolFromStagingPath() = %q, want %q", got, ProtocolNVMeOF)
+	}
+	derived, err := service.deriveNQNFromStagingPath(context.Background(), stagingPath)
+	if err != nil || derived != nqn {
+		t.Fatalf("deriveNQNFromStagingPath() = %q, %v; want %q, nil", derived, err, nqn)
+	}
+
+	service.disconnectNVMeOFFn = func(_ context.Context, gotNQN string) error {
+		if gotNQN != nqn {
+			t.Errorf("disconnect NQN = %q, want %q", gotNQN, nqn)
+		}
+		return nil
+	}
+	resp, err := service.unstageNVMeOFVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "tank/volumes/test-volume",
+		StagingTargetPath: stagingPath,
+	}, nil)
+	if err != nil || resp == nil {
+		t.Fatalf("unstageNVMeOFVolume() = %#v, %v; want non-nil response, nil", resp, err)
+	}
+	if _, statErr := os.Stat(nvmeStagingMetadataPath(stagingPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("staging metadata still exists after successful unstage: %v", statErr)
+	}
+}
+
+func writeTestSubsystemNQN(t *testing.T, sysClassPath, controller, nqn string) string {
+	t.Helper()
+	controllerPath := filepath.Join(sysClassPath, controller)
+	if err := os.MkdirAll(controllerPath, 0o750); err != nil {
+		t.Fatalf("failed to create test controller path: %v", err)
+	}
+	nqnPath := filepath.Join(controllerPath, "subsysnqn")
+	if err := os.WriteFile(nqnPath, []byte(nqn+"\n"), 0o600); err != nil {
+		t.Fatalf("failed to write test NQN: %v", err)
+	}
+	return nqnPath
+}


### PR DESCRIPTION
## Summary

- return NodeUnstageVolume errors when the NQN cannot be recovered or disconnect/cleanup fails
- persist the NQN beside the staging path so disconnect retries cannot be misclassified as NFS cleanup
- serialize kernel NVMe connect/disconnect transitions and poll sysfs until the exact NQN disappears
- decode nvme list-subsys JSON with exact NQN matching instead of heuristic substring scanning
- add regression coverage for cleanup timeouts, disconnect failures, exact identity, and unstage retries

## Testing

- `go test -race -short ./pkg/driver/...`
- `go test -short ./pkg/... ./cmd/kubectl-tns-csi/...`
- `golangci-lint run --config .golangci.yml ./...`
- `go build ./cmd/tns-csi-driver ./cmd/kubectl-tns-csi`

## Validation

Real NVMe-oF rapid-churn validation remains to be run in the reporter's environment.

Fixes #204