### PR TITLE
fix: scope iSCSI device discovery to requested target

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -39,6 +39,7 @@ type NodeService struct {
 	apiClient       tnsapi.ClientInterface
 	nodeRegistry    *NodeRegistry
 	nvmeConnectSem  chan struct{}
+	iscsiDiscovery  *iscsiDeviceDiscoveryConfig
 	nodeID          string
 	testMode        bool
 	enableDiscovery bool
@@ -56,6 +57,7 @@ func NewNodeService(nodeID string, apiClient tnsapi.ClientInterface, testMode bo
 		nodeRegistry:    nodeRegistry,
 		enableDiscovery: enableDiscovery,
 		nvmeConnectSem:  make(chan struct{}, maxConcurrentNVMeConnects),
+		iscsiDiscovery:  defaultISCSIDeviceDiscoveryConfig(),
 	}
 }
 

--- a/pkg/driver/node_block_device.go
+++ b/pkg/driver/node_block_device.go
@@ -76,15 +76,9 @@ func waitForDeviceInitialization(ctx context.Context, devicePath string) error {
 func forceDeviceRescan(ctx context.Context, devicePath string) error {
 	klog.V(4).Infof("Forcing device rescan for %s to clear kernel caches", devicePath)
 
-	// Step 1: Sync and flush device buffers
-	syncCtx, syncCancel := context.WithTimeout(ctx, 5*time.Second)
-	defer syncCancel()
-	syncCmd := exec.CommandContext(syncCtx, "sync")
-	if output, err := syncCmd.CombinedOutput(); err != nil {
-		klog.V(4).Infof("sync command failed: %v, output: %s", err, string(output))
-	}
-
-	// Step 2: Flush device buffers
+	// Step 1: Flush only the target device. A host-wide sync can block
+	// indefinitely on an unrelated stale network filesystem and prevent this
+	// volume from reaching NodeStageVolume's mount step.
 	flushCtx, flushCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer flushCancel()
 	flushCmd := exec.CommandContext(flushCtx, "blockdev", "--flushbufs", devicePath)
@@ -94,7 +88,7 @@ func forceDeviceRescan(ctx context.Context, devicePath string) error {
 		klog.V(4).Infof("Flushed device buffers for %s", devicePath)
 	}
 
-	// Step 3: Trigger udev to re-process the device
+	// Step 2: Trigger udev to re-process the device
 	udevCtx, udevCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer udevCancel()
 	udevCmd := exec.CommandContext(udevCtx, "udevadm", "trigger", "--action=change", devicePath)
@@ -104,7 +98,7 @@ func forceDeviceRescan(ctx context.Context, devicePath string) error {
 		klog.V(4).Infof("Triggered udev change event for %s", devicePath)
 	}
 
-	// Step 4: Wait for udev to settle
+	// Step 3: Wait for udev to settle
 	settleCtx, settleCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer settleCancel()
 	settleCmd := exec.CommandContext(settleCtx, "udevadm", "settle", "--timeout=5")

--- a/pkg/driver/node_block_device_test.go
+++ b/pkg/driver/node_block_device_test.go
@@ -1,0 +1,50 @@
+package driver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestForceDeviceRescanFlushesOnlyTargetDevice(t *testing.T) {
+	binDir := t.TempDir()
+	commandLog := filepath.Join(t.TempDir(), "commands.log")
+
+	writeCommand := func(name, body string) {
+		t.Helper()
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+			t.Fatalf("write fake %s command: %v", name, err)
+		}
+	}
+
+	writeCommand("sync", `printf 'sync\n' >> "$COMMAND_LOG"`)
+	writeCommand("blockdev", `printf 'blockdev %s\n' "$*" >> "$COMMAND_LOG"`)
+	writeCommand("udevadm", `printf 'udevadm %s\n' "$*" >> "$COMMAND_LOG"`)
+
+	t.Setenv("COMMAND_LOG", commandLog)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := forceDeviceRescan(context.Background(), "/dev/test-lun"); err != nil {
+		t.Fatalf("forceDeviceRescan returned an error: %v", err)
+	}
+
+	output, err := os.ReadFile(commandLog)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	commands := string(output)
+
+	if strings.Contains(commands, "sync\n") {
+		t.Fatal("forceDeviceRescan must not run host-wide sync")
+	}
+	const expected = "" +
+		"blockdev --flushbufs /dev/test-lun\n" +
+		"udevadm trigger --action=change /dev/test-lun\n" +
+		"udevadm settle --timeout=5\n"
+	if commands != expected {
+		t.Fatalf("unexpected rescan command sequence:\n%s", commands)
+	}
+}

--- a/pkg/driver/node_iscsi.go
+++ b/pkg/driver/node_iscsi.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +23,9 @@ import (
 var (
 	ErrISCSIAdmNotFound     = errors.New("iscsiadm command not found - please install open-iscsi")
 	ErrISCSIDeviceNotFound  = errors.New("iSCSI device not found")
+	ErrISCSIDeviceAmbiguous = errors.New("multiple iSCSI devices found")
+	ErrISCSIDeviceInvalid   = errors.New("invalid iSCSI device state")
+	ErrISCSINotBlockDevice  = errors.New("iSCSI device is not a block device")
 	ErrISCSIDeviceTimeout   = errors.New("timeout waiting for iSCSI device to appear")
 	ErrISCSILoginFailed     = errors.New("failed to login to iSCSI target")
 	ErrISCSIDiscoveryFailed = errors.New("iSCSI discovery failed - iscsid may not be running or accessible")
@@ -58,6 +64,22 @@ type iscsiConnectionParams struct {
 	lun    int
 }
 
+type iscsiDeviceDiscoveryConfig struct {
+	validateDevice     func(string) error
+	sessionClassDir    string
+	connectionClassDir string
+	deviceDir          string
+}
+
+func defaultISCSIDeviceDiscoveryConfig() *iscsiDeviceDiscoveryConfig {
+	return &iscsiDeviceDiscoveryConfig{
+		validateDevice:     validateISCSIBlockDevice,
+		sessionClassDir:    "/sys/class/iscsi_session",
+		connectionClassDir: "/sys/class/iscsi_connection",
+		deviceDir:          "/dev",
+	}
+}
+
 // stageISCSIVolume stages an iSCSI volume by logging into the target.
 // It uses a retry mechanism to handle transient device stability issues.
 func (s *NodeService) stageISCSIVolume(ctx context.Context, req *csi.NodeStageVolumeRequest, volumeContext map[string]string) (*csi.NodeStageVolumeResponse, error) {
@@ -76,10 +98,16 @@ func (s *NodeService) stageISCSIVolume(ctx context.Context, req *csi.NodeStageVo
 	klog.V(4).Infof("Staging iSCSI volume %s (block mode: %v): server=%s:%s, IQN=%s, LUN=%d, dataset=%s",
 		volumeID, isBlockVolume, params.server, params.port, params.iqn, params.lun, datasetName)
 
-	// Try to reuse existing connection (idempotency)
-	if devicePath, findErr := s.findISCSIDevice(ctx, params); findErr == nil && devicePath != "" {
+	// Try to reuse an existing connection. Only a definitive not-found result
+	// may fall through to login; ambiguous or unreadable identity state must
+	// not mutate host sessions.
+	devicePath, findErr := s.findISCSIDevice(ctx, params)
+	if findErr == nil && devicePath != "" {
 		klog.V(4).Infof("iSCSI device already connected at %s - reusing existing connection", devicePath)
 		return s.stageISCSIDevice(ctx, volumeID, devicePath, stagingTargetPath, volumeCapability, isBlockVolume, volumeContext)
+	}
+	if findErr != nil && !errors.Is(findErr, ErrISCSIDeviceNotFound) {
+		return nil, iscsiDiscoveryStatusError(findErr)
 	}
 
 	// Check if iscsiadm is installed
@@ -114,6 +142,9 @@ func (s *NodeService) stageISCSIVolume(ctx context.Context, req *csi.NodeStageVo
 		// Wait for device to appear
 		devicePath, err := s.waitForISCSIDevice(ctx, params, 30*time.Second)
 		if err != nil {
+			if !errors.Is(err, ErrISCSIDeviceTimeout) && !errors.Is(err, ErrISCSIDeviceNotFound) {
+				return nil, iscsiDiscoveryStatusError(err)
+			}
 			lastErr = err
 			klog.Warningf("iSCSI device wait failed on attempt %d: %v", attempt, err)
 			// Cleanup: logout before retry
@@ -155,6 +186,13 @@ func (s *NodeService) stageISCSIVolume(ctx context.Context, req *csi.NodeStageVo
 
 	// All retries exhausted
 	return nil, status.Errorf(codes.Internal, "Failed to stage iSCSI volume after %d attempts: %v", maxRetries, lastErr)
+}
+
+func iscsiDiscoveryStatusError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Err()
+	}
+	return status.Errorf(codes.FailedPrecondition, "cannot safely identify iSCSI device: %v", err)
 }
 
 // validateISCSIParams validates and extracts iSCSI connection parameters from volume context.
@@ -285,84 +323,289 @@ func (s *NodeService) logoutISCSITarget(ctx context.Context, params *iscsiConnec
 
 // findISCSIDevice finds the device path for an iSCSI LUN.
 func (s *NodeService) findISCSIDevice(ctx context.Context, params *iscsiConnectionParams) (string, error) {
-	// Query active sessions with detail level 3 to see attached devices
-	sessionCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
+	config := s.iscsiDiscovery
+	if config == nil ||
+		config.sessionClassDir == "" ||
+		config.connectionClassDir == "" ||
+		config.deviceDir == "" ||
+		config.validateDevice == nil {
 
-	cmd := iscsiadmCmd(sessionCtx, "-m", "session", "-P", "3")
-	output, err := cmd.CombinedOutput()
+		config = defaultISCSIDeviceDiscoveryConfig()
+	}
 
-	// Always log the output for debugging
-	klog.Infof("iscsiadm -m session -P 3: err=%v, output:\n%s", err, string(output))
-
+	devicePath, err := findISCSIDeviceInSysfs(ctx, config, params)
 	if err != nil {
-		return "", ErrISCSIDeviceNotFound
+		klog.V(4).Infof("iSCSI sysfs lookup failed for IQN %s LUN %d: %v", params.iqn, params.lun, err)
+		return "", err
 	}
 
-	deviceName := parseISCSISessionDevice(string(output), params.iqn)
-	if deviceName == "" {
-		klog.Infof("parseISCSISessionDevice found no device for IQN: %s", params.iqn)
-		return "", ErrISCSIDeviceNotFound
-	}
-
-	devicePath := "/dev/" + deviceName
-	klog.Infof("Found iSCSI device: %s", devicePath)
+	klog.Infof("Found iSCSI device in sysfs: %s (IQN: %s, LUN: %d)", devicePath, params.iqn, params.lun)
 	return devicePath, nil
 }
 
-// parseISCSISessionDevice parses iscsiadm -m session -P 3 output to find
-// the attached disk for a specific IQN.
-func parseISCSISessionDevice(output, targetIQN string) string {
-	lines := strings.Split(output, "\n")
-	inTargetSection := false
+func findISCSIDeviceInSysfs(
+	ctx context.Context,
+	config *iscsiDeviceDiscoveryConfig,
+	params *iscsiConnectionParams,
+) (string, error) {
 
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 
-		// Check if we're entering a target section
-		// Format: "Target: iqn.2005-10.org.freenas.ctl:pvc-xxx (non-flash)"
-		// The IQN might be followed by extra text like "(non-flash)"
-		if strings.HasPrefix(line, "Target:") {
-			targetLine := strings.TrimPrefix(line, "Target:")
-			targetLine = strings.TrimSpace(targetLine)
-			// Check if this line contains our target IQN (use Contains/HasPrefix
-			// because there might be extra text after the IQN)
-			inTargetSection = strings.HasPrefix(targetLine, targetIQN)
+	sessionEntries, err := os.ReadDir(config.sessionClassDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("%w for IQN %s: session class is not present", ErrISCSIDeviceNotFound, params.iqn)
+		}
+		return "", fmt.Errorf("%w: read session class %s: %w", ErrISCSIDeviceInvalid, config.sessionClassDir, err)
+	}
+
+	var matchingSessions []string
+	for _, entry := range sessionEntries {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
+		if !strings.HasPrefix(entry.Name(), "session") {
 			continue
 		}
 
-		// If we're in the right target section, look for attached disk
-		if inTargetSection && strings.Contains(line, "Attached scsi disk") {
-			// Line format: "Attached scsi disk sda	State: running"
-			parts := strings.Fields(line)
-			for i, part := range parts {
-				if part == "disk" && i+1 < len(parts) {
-					return parts[i+1] // Return device name like "sda"
+		sessionPath := filepath.Join(config.sessionClassDir, entry.Name())
+		//nolint:gosec // The path is bounded to kernel-created sysfs session entries.
+		targetName, readErr := os.ReadFile(filepath.Join(sessionPath, "targetname"))
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				continue
+			}
+			return "", fmt.Errorf("%w: read target name for %s: %w", ErrISCSIDeviceInvalid, entry.Name(), readErr)
+		}
+		if strings.TrimSpace(string(targetName)) == params.iqn {
+			matchingSessions = append(matchingSessions, sessionPath)
+		}
+	}
+
+	if len(matchingSessions) == 0 {
+		return "", fmt.Errorf("%w for IQN %s", ErrISCSIDeviceNotFound, params.iqn)
+	}
+	if len(matchingSessions) > 1 {
+		matchingSessions, err = filterISCSISessionsByPortal(ctx, config.connectionClassDir, matchingSessions, params)
+		if err != nil {
+			return "", err
+		}
+	}
+	if len(matchingSessions) > 1 {
+		return "", fmt.Errorf("%w for IQN %s: %d exact sessions", ErrISCSIDeviceAmbiguous, params.iqn, len(matchingSessions))
+	}
+
+	resolvedDeviceDir, err := filepath.EvalSymlinks(filepath.Join(matchingSessions[0], "device"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("%w for IQN %s: session device disappeared", ErrISCSIDeviceNotFound, params.iqn)
+		}
+		return "", fmt.Errorf("%w: resolve session device for IQN %s: %w", ErrISCSIDeviceInvalid, params.iqn, err)
+	}
+
+	deviceNames, err := findISCSILUNDeviceNames(ctx, resolvedDeviceDir, params.lun)
+	if err != nil {
+		return "", err
+	}
+	if len(deviceNames) == 0 {
+		return "", fmt.Errorf("%w for IQN %s LUN %d", ErrISCSIDeviceNotFound, params.iqn, params.lun)
+	}
+	if len(deviceNames) > 1 {
+		return "", fmt.Errorf("%w for IQN %s LUN %d: %v", ErrISCSIDeviceAmbiguous, params.iqn, params.lun, deviceNames)
+	}
+
+	devicePath := filepath.Join(config.deviceDir, deviceNames[0])
+	if _, statErr := os.Stat(devicePath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return "", fmt.Errorf("%w for IQN %s: device node %s not ready", ErrISCSIDeviceNotFound, params.iqn, devicePath)
+		}
+		return "", fmt.Errorf("%w: stat device node %s: %w", ErrISCSIDeviceInvalid, devicePath, statErr)
+	}
+	if validateErr := config.validateDevice(devicePath); validateErr != nil {
+		if os.IsNotExist(validateErr) {
+			return "", fmt.Errorf("%w for IQN %s: device node %s disappeared", ErrISCSIDeviceNotFound, params.iqn, devicePath)
+		}
+		return "", fmt.Errorf("%w: validate device node %s: %w", ErrISCSIDeviceInvalid, devicePath, validateErr)
+	}
+
+	return devicePath, nil
+}
+
+func filterISCSISessionsByPortal(
+	ctx context.Context,
+	connectionClassDir string,
+	sessions []string,
+	params *iscsiConnectionParams,
+) ([]string, error) {
+
+	if params.server == "" || params.port == "" {
+		return sessions, nil
+	}
+
+	connectionEntries, err := os.ReadDir(connectionClassDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return sessions, nil
+		}
+		return nil, fmt.Errorf("%w: read connection class %s: %w", ErrISCSIDeviceInvalid, connectionClassDir, err)
+	}
+
+	matchingPortals := make([]string, 0, len(sessions))
+	for _, sessionPath := range sessions {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+
+		sessionNumber := strings.TrimPrefix(filepath.Base(sessionPath), "session")
+		connectionPrefix := "connection" + sessionNumber + ":"
+		sessionMatches := false
+		for _, connectionEntry := range connectionEntries {
+			if !strings.HasPrefix(connectionEntry.Name(), connectionPrefix) {
+				continue
+			}
+
+			connectionPath := filepath.Join(connectionClassDir, connectionEntry.Name())
+			//nolint:gosec // The path is bounded to kernel-created sysfs connection entries.
+			address, readErr := os.ReadFile(filepath.Join(connectionPath, "address"))
+			if readErr != nil {
+				if os.IsNotExist(readErr) {
+					continue
 				}
+				return nil, fmt.Errorf("%w: read address for %s: %w", ErrISCSIDeviceInvalid, connectionEntry.Name(), readErr)
+			}
+			//nolint:gosec // The path is bounded to kernel-created sysfs connection entries.
+			port, readErr := os.ReadFile(filepath.Join(connectionPath, "port"))
+			if readErr != nil {
+				if os.IsNotExist(readErr) {
+					continue
+				}
+				return nil, fmt.Errorf("%w: read port for %s: %w", ErrISCSIDeviceInvalid, connectionEntry.Name(), readErr)
+			}
+
+			if strings.TrimSpace(string(address)) == params.server &&
+				strings.TrimSpace(string(port)) == params.port {
+
+				sessionMatches = true
+				break
+			}
+		}
+		if sessionMatches {
+			matchingPortals = append(matchingPortals, sessionPath)
+		}
+	}
+
+	if len(matchingPortals) == 0 {
+		return sessions, nil
+	}
+	return matchingPortals, nil
+}
+
+func findISCSILUNDeviceNames(ctx context.Context, sessionDeviceDir string, lun int) ([]string, error) {
+	targetEntries, err := os.ReadDir(sessionDeviceDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: read session device directory %s: %w", ErrISCSIDeviceInvalid, sessionDeviceDir, err)
+	}
+
+	devices := make(map[string]struct{})
+	for _, targetEntry := range targetEntries {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if !strings.HasPrefix(targetEntry.Name(), "target") {
+			continue
+		}
+
+		targetPath := filepath.Join(sessionDeviceDir, targetEntry.Name())
+		scsiEntries, readErr := os.ReadDir(targetPath)
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				continue
+			}
+			return nil, fmt.Errorf("%w: read SCSI target %s: %w", ErrISCSIDeviceInvalid, targetPath, readErr)
+		}
+
+		for _, scsiEntry := range scsiEntries {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			if !scsiAddressMatchesLUN(scsiEntry.Name(), lun) {
+				continue
+			}
+
+			blockPath := filepath.Join(targetPath, scsiEntry.Name(), "block")
+			blockEntries, readErr := os.ReadDir(blockPath)
+			if readErr != nil {
+				if os.IsNotExist(readErr) {
+					continue
+				}
+				return nil, fmt.Errorf("%w: read block devices at %s: %w", ErrISCSIDeviceInvalid, blockPath, readErr)
+			}
+			for _, blockEntry := range blockEntries {
+				devices[blockEntry.Name()] = struct{}{}
 			}
 		}
 	}
 
-	return ""
+	deviceNames := make([]string, 0, len(devices))
+	for deviceName := range devices {
+		deviceNames = append(deviceNames, deviceName)
+	}
+	sort.Strings(deviceNames)
+	return deviceNames, nil
+}
+
+func scsiAddressMatchesLUN(address string, lun int) bool {
+	parts := strings.Split(address, ":")
+	if len(parts) != 4 {
+		return false
+	}
+	addressLUN, err := strconv.Atoi(parts[3])
+	return err == nil && addressLUN == lun
+}
+
+func validateISCSIBlockDevice(devicePath string) error {
+	info, err := os.Stat(devicePath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
+		return fmt.Errorf("%w: %s", ErrISCSINotBlockDevice, devicePath)
+	}
+	return nil
 }
 
 // waitForISCSIDevice waits for the iSCSI device to appear after login.
 func (s *NodeService) waitForISCSIDevice(ctx context.Context, params *iscsiConnectionParams, timeout time.Duration) (string, error) {
 	klog.Infof("Waiting for iSCSI device for IQN %s (timeout: %v)", params.iqn, timeout)
 
-	deadline := time.Now().Add(timeout)
-	for attempt := 1; time.Now().Before(deadline); attempt++ {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for attempt := 1; ; attempt++ {
 		devicePath, err := s.findISCSIDevice(ctx, params)
 		if err == nil && devicePath != "" {
-			if _, statErr := os.Stat(devicePath); statErr == nil {
-				klog.Infof("iSCSI device ready: %s (attempt %d)", devicePath, attempt)
-				return devicePath, nil
-			}
+			klog.Infof("iSCSI device ready: %s (attempt %d)", devicePath, attempt)
+			return devicePath, nil
 		}
-		time.Sleep(2 * time.Second)
-	}
+		if err != nil && !errors.Is(err, ErrISCSIDeviceNotFound) {
+			return "", err
+		}
 
-	return "", ErrISCSIDeviceTimeout
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-timer.C:
+			return "", ErrISCSIDeviceTimeout
+		case <-ticker.C:
+		}
+	}
 }
 
 // stageISCSIDevice stages an iSCSI device as either block or filesystem volume.

--- a/pkg/driver/node_iscsi_sysfs_test.go
+++ b/pkg/driver/node_iscsi_sysfs_test.go
@@ -1,0 +1,339 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const testISCSIIQN = "iqn.2005-10.org.freenas.ctl:pvc-test"
+
+type fakeISCSITree struct {
+	root          string
+	sessionDir    string
+	connectionDir string
+	deviceDir     string
+}
+
+func newFakeISCSITree(t *testing.T) *fakeISCSITree {
+	t.Helper()
+
+	root := t.TempDir()
+	tree := &fakeISCSITree{
+		root:          root,
+		sessionDir:    filepath.Join(root, "sys", "class", "iscsi_session"),
+		connectionDir: filepath.Join(root, "sys", "class", "iscsi_connection"),
+		deviceDir:     filepath.Join(root, "dev"),
+	}
+	for _, dir := range []string{tree.sessionDir, tree.connectionDir, tree.deviceDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create fake iSCSI directory %s: %v", dir, err)
+		}
+	}
+	return tree
+}
+
+func (f *fakeISCSITree) addSession(t *testing.T, name, iqn string, lunDevices map[int][]string) {
+	t.Helper()
+
+	sessionPath := filepath.Join(f.sessionDir, name)
+	if err := os.MkdirAll(sessionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, "targetname"), []byte(iqn+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	devicePath := filepath.Join(f.root, "sys", "devices", name)
+	for lun, devices := range lunDevices {
+		blockPath := filepath.Join(devicePath, "target46:0:0", scsiAddressForLUN(lun), "block")
+		if err := os.MkdirAll(blockPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, device := range devices {
+			if err := os.WriteFile(filepath.Join(blockPath, device), nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(f.deviceDir, device), nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if err := os.Symlink(devicePath, filepath.Join(sessionPath, "device")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *fakeISCSITree) addConnection(t *testing.T, sessionNumber, address, port string) {
+	t.Helper()
+
+	connectionPath := filepath.Join(f.connectionDir, "connection"+sessionNumber+":0")
+	if err := os.MkdirAll(connectionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(connectionPath, "address"), []byte(address+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(connectionPath, "port"), []byte(port+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *fakeISCSITree) config() *iscsiDeviceDiscoveryConfig {
+	return &iscsiDeviceDiscoveryConfig{
+		validateDevice:     func(string) error { return nil },
+		sessionClassDir:    f.sessionDir,
+		connectionClassDir: f.connectionDir,
+		deviceDir:          f.deviceDir,
+	}
+}
+
+func scsiAddressForLUN(lun int) string {
+	return "46:0:0:" + strconv.Itoa(lun)
+}
+
+func TestFindISCSIDeviceInSysfsSelectsExactIdentity(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", "  "+testISCSIIQN+"  ", map[int][]string{
+		0:  {"sdae"},
+		1:  {"sdaf"},
+		12: {"sdag"},
+	})
+
+	for _, testCase := range []struct {
+		name string
+		want string
+		lun  int
+	}{
+		{name: "lun zero", lun: 0, want: "sdae"},
+		{name: "multi digit lun", lun: 12, want: "sdag"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := findISCSIDeviceInSysfs(
+				context.Background(),
+				tree.config(),
+				&iscsiConnectionParams{iqn: testISCSIIQN, lun: testCase.lun},
+			)
+			if err != nil {
+				t.Fatalf("findISCSIDeviceInSysfs() error = %v", err)
+			}
+			if want := filepath.Join(tree.deviceDir, testCase.want); got != want {
+				t.Fatalf("findISCSIDeviceInSysfs() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestFindISCSIDeviceInSysfsRejectsIQNPrefix(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", testISCSIIQN+"-other", map[int][]string{0: {"sdae"}})
+
+	_, err := findISCSIDeviceInSysfs(
+		context.Background(),
+		tree.config(),
+		&iscsiConnectionParams{iqn: testISCSIIQN, lun: 0},
+	)
+	if !errors.Is(err, ErrISCSIDeviceNotFound) {
+		t.Fatalf("error = %v, want ErrISCSIDeviceNotFound", err)
+	}
+}
+
+func TestFindISCSIDeviceInSysfsFiltersDuplicateIQNByPortal(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", testISCSIIQN, map[int][]string{0: {"sdae"}})
+	tree.addConnection(t, "31", "10.0.70.11", "3260")
+	tree.addSession(t, "session32", testISCSIIQN, map[int][]string{0: {"sdaf"}})
+	tree.addConnection(t, "32", "10.0.70.10", "3260")
+
+	got, err := findISCSIDeviceInSysfs(
+		context.Background(),
+		tree.config(),
+		&iscsiConnectionParams{
+			iqn:    testISCSIIQN,
+			server: "10.0.70.10",
+			port:   "3260",
+			lun:    0,
+		},
+	)
+	if err != nil {
+		t.Fatalf("findISCSIDeviceInSysfs() error = %v", err)
+	}
+	if want := filepath.Join(tree.deviceDir, "sdaf"); got != want {
+		t.Fatalf("findISCSIDeviceInSysfs() = %q, want %q", got, want)
+	}
+}
+
+func TestFindISCSIDeviceInSysfsRejectsAmbiguity(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", testISCSIIQN, map[int][]string{0: {"sdae"}})
+	tree.addSession(t, "session32", testISCSIIQN, map[int][]string{0: {"sdaf"}})
+
+	_, err := findISCSIDeviceInSysfs(
+		context.Background(),
+		tree.config(),
+		&iscsiConnectionParams{iqn: testISCSIIQN, lun: 0},
+	)
+	if !errors.Is(err, ErrISCSIDeviceAmbiguous) {
+		t.Fatalf("error = %v, want ErrISCSIDeviceAmbiguous", err)
+	}
+}
+
+func TestFindISCSIDeviceInSysfsRejectsMultipleDevicesForLUN(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", testISCSIIQN, map[int][]string{0: {"sdae", "sdaf"}})
+
+	_, err := findISCSIDeviceInSysfs(
+		context.Background(),
+		tree.config(),
+		&iscsiConnectionParams{iqn: testISCSIIQN, lun: 0},
+	)
+	if !errors.Is(err, ErrISCSIDeviceAmbiguous) {
+		t.Fatalf("error = %v, want ErrISCSIDeviceAmbiguous", err)
+	}
+}
+
+func TestFindISCSIDeviceInSysfsFindsDeviceAfterRetryableMiss(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", testISCSIIQN, nil)
+	params := &iscsiConnectionParams{iqn: testISCSIIQN, lun: 0}
+
+	if _, err := findISCSIDeviceInSysfs(context.Background(), tree.config(), params); !errors.Is(err, ErrISCSIDeviceNotFound) {
+		t.Fatalf("first error = %v, want ErrISCSIDeviceNotFound", err)
+	}
+
+	blockPath := filepath.Join(
+		tree.root,
+		"sys",
+		"devices",
+		"session31",
+		"target46:0:0",
+		scsiAddressForLUN(0),
+		"block",
+	)
+	if err := os.MkdirAll(blockPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blockPath, "sdae"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tree.deviceDir, "sdae"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findISCSIDeviceInSysfs(context.Background(), tree.config(), params)
+	if err != nil {
+		t.Fatalf("second lookup error = %v", err)
+	}
+	if want := filepath.Join(tree.deviceDir, "sdae"); got != want {
+		t.Fatalf("second lookup = %q, want %q", got, want)
+	}
+}
+
+func TestFindISCSIDeviceInSysfsTreatsDisappearingSessionAsRetryable(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	sessionPath := filepath.Join(tree.sessionDir, "session31")
+	if err := os.MkdirAll(sessionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, "targetname"), []byte(testISCSIIQN), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(tree.root, "missing"), filepath.Join(sessionPath, "device")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := findISCSIDeviceInSysfs(
+		context.Background(),
+		tree.config(),
+		&iscsiConnectionParams{iqn: testISCSIIQN, lun: 0},
+	)
+	if !errors.Is(err, ErrISCSIDeviceNotFound) {
+		t.Fatalf("error = %v, want ErrISCSIDeviceNotFound", err)
+	}
+}
+
+func TestValidateISCSIBlockDeviceRejectsRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-block-device")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := validateISCSIBlockDevice(path)
+	if !errors.Is(err, ErrISCSINotBlockDevice) {
+		t.Fatalf("error = %v, want ErrISCSINotBlockDevice", err)
+	}
+}
+
+func TestStageISCSIVolumeFailsClosedOnAmbiguousDiscovery(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", testISCSIIQN, map[int][]string{0: {"sdae"}})
+	tree.addSession(t, "session32", testISCSIIQN, map[int][]string{0: {"sdaf"}})
+
+	commandDir := t.TempDir()
+	sentinel := filepath.Join(commandDir, "iscsiadm-invoked")
+	script := "#!/bin/sh\n: > \"" + sentinel + "\"\n/bin/sleep 30\n"
+	for _, name := range []string{"iscsiadm", "nsenter"} {
+		if err := os.WriteFile(filepath.Join(commandDir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", commandDir)
+
+	service := NewNodeService("test-node", nil, true, NewNodeRegistry(), false, 1)
+	service.iscsiDiscovery = tree.config()
+	request := &csi.NodeStageVolumeRequest{
+		VolumeId:          "pvc-test",
+		StagingTargetPath: filepath.Join(t.TempDir(), "stage"),
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{FsType: fsTypeExt4},
+			},
+		},
+	}
+	volumeContext := map[string]string{
+		VolumeContextKeyISCSIIQN: testISCSIIQN,
+		"server":                 "10.0.70.10",
+		"port":                   "3260",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	_, err := service.stageISCSIVolume(ctx, request, volumeContext)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("status code = %s, want FailedPrecondition; error = %v", status.Code(err), err)
+	}
+	if _, statErr := os.Stat(sentinel); !os.IsNotExist(statErr) {
+		t.Fatalf("iscsiadm command was invoked; stat error = %v", statErr)
+	}
+}
+
+func TestWaitForISCSIDeviceFailsClosedOnAmbiguousDiscovery(t *testing.T) {
+	tree := newFakeISCSITree(t)
+	tree.addSession(t, "session31", testISCSIIQN, map[int][]string{0: {"sdae"}})
+	tree.addSession(t, "session32", testISCSIIQN, map[int][]string{0: {"sdaf"}})
+
+	service := NewNodeService("test-node", nil, true, NewNodeRegistry(), false, 1)
+	service.iscsiDiscovery = tree.config()
+	start := time.Now()
+
+	_, err := service.waitForISCSIDevice(
+		context.Background(),
+		&iscsiConnectionParams{iqn: testISCSIIQN, lun: 0},
+		10*time.Second,
+	)
+	if !errors.Is(err, ErrISCSIDeviceAmbiguous) {
+		t.Fatalf("error = %v, want ErrISCSIDeviceAmbiguous", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("fatal discovery error was retried for %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

- remove the host-wide `sync` call from device rescans and flush only the requested block device
- discover iSCSI devices through sysfs using exact IQN and LUN matching, with portal disambiguation when duplicate sessions exist
- fail closed on ambiguous or invalid device identity instead of logging in, logging out, or retrying a potentially wrong session
- validate the selected `/dev` node is a real block device

## Root cause

`NodeStageVolume` used a host-wide `sync` during device initialization and parsed `iscsiadm -m session -P 3` output across every active session. A stale unrelated filesystem could block the global sync, while prefix-based IQN parsing and unscoped session output could select or retry the wrong device when sessions overlapped.

The new lookup follows `/sys/class/iscsi_session/session*/device`, matches the exact target identity and requested LUN, and treats races as retryable only when the device is genuinely not present.

## Validation

- `make test-unit`
- `make build`
- `go vet ./...`
- `golangci-lint v2.12.2 run --config .golangci.yml`
- focused regression tests cover exact and prefix IQNs, LUN 0 and multi-digit LUNs, duplicate sessions, portal selection, multiple devices for one LUN, disappearing sessions, delayed device appearance, non-block nodes, and fail-closed staging without invoking `iscsiadm`

TrueNAS-backed E2E suites were not run locally because they require an external TrueNAS test environment and credentials.