### PR TITLE
fix(chart): enable cluster DNS for node pods

### DIFF
--- a/charts/tns-csi-driver/templates/node.yaml
+++ b/charts/tns-csi-driver/templates/node.yaml
@@ -39,6 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true   # Required for iSCSI nsenter to access host's iscsid (Talos)
       hostIPC: true   # Required for iSCSI to communicate with host's iscsid daemon
       containers:


### PR DESCRIPTION
## Summary

- set `dnsPolicy: ClusterFirstWithHostNet` on the host-networked node DaemonSet
- allow node plugins to resolve Kubernetes Service and ExternalName records

## Testing

- `helm lint charts/tns-csi-driver` with required TrueNAS and StorageClass values
- `helm template` confirms the rendered DaemonSet contains `dnsPolicy: ClusterFirstWithHostNet`
- `git diff --check`

Fixes #172