### PR TITLE
fix(iscsi): preserve target identity on unstage

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -42,10 +42,14 @@ type NodeService struct {
 	nvmeConnectSem chan struct{}
 	// disconnectNVMeOFFn is overridden by focused node-service tests.
 	disconnectNVMeOFFn func(context.Context, string) error
-	nodeID             string
-	nvmeLifecycleMu    sync.Mutex
-	testMode           bool
-	enableDiscovery    bool
+	// logoutISCSITargetFn is overridden by focused node-service tests.
+	logoutISCSITargetFn func(context.Context, *iscsiConnectionParams) error
+	// runISCSIAdmFn is overridden by focused command-result tests.
+	runISCSIAdmFn   func(context.Context, ...string) ([]byte, error)
+	nodeID          string
+	nvmeLifecycleMu sync.Mutex
+	testMode        bool
+	enableDiscovery bool
 }
 
 // NewNodeService creates a new node service.
@@ -176,11 +180,9 @@ func (s *NodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		return resp, nil
 
 	case ProtocolISCSI:
-		// For iSCSI, we need to pass the IQN which is derived from the volume ID
-		// IQN format is: iqn.2024-01.io.truenas.csi:<volumeID>
-		volumeContext := map[string]string{
-			VolumeContextKeyISCSIIQN: "iqn.2024-01.io.truenas.csi:" + volumeID,
-		}
+		// NodeUnstageVolume does not include VolumeContext. The real IQN is
+		// recovered from staging metadata or the attached iSCSI session.
+		volumeContext := map[string]string{}
 		resp, err := s.unstageISCSIVolume(ctx, req, volumeContext)
 		if err != nil {
 			timer.ObserveError()
@@ -220,6 +222,12 @@ func (s *NodeService) detectProtocolFromStagingPath(ctx context.Context, staging
 		return ProtocolNVMeOF
 	} else if nqn != "" {
 		return ProtocolNVMeOF
+	}
+	if iqn, err := readISCSIStagingIQN(stagingPath); err != nil {
+		klog.Warningf("iSCSI staging metadata for %s is invalid: %v", stagingPath, err)
+		return ProtocolISCSI
+	} else if iqn != "" {
+		return ProtocolISCSI
 	}
 
 	// Check if the path exists first

--- a/pkg/driver/node_iscsi.go
+++ b/pkg/driver/node_iscsi.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -24,10 +25,15 @@ var (
 	ErrISCSILoginFailed     = errors.New("failed to login to iSCSI target")
 	ErrISCSIDiscoveryFailed = errors.New("iSCSI discovery failed - iscsid may not be running or accessible")
 	ErrISCSITargetNotInDB   = errors.New("iSCSI target not found in node database after discovery")
+	ErrISCSIEmptyIQN        = errors.New("empty iSCSI IQN")
+	ErrISCSILogoutTimeout   = errors.New("timeout waiting for iSCSI session logout")
+	ErrISCSINonDevicePath   = errors.New("iSCSI staging path resolved to a non-device path")
 )
 
 // defaultISCSIMountOptions are sensible defaults for iSCSI filesystem mounts.
 var defaultISCSIMountOptions = []string{zfsNoatime, "_netdev"}
+
+const iscsiStagingMetadataSuffix = ".tns-csi-iscsi"
 
 // iscsiadmCmd builds a command to run iscsiadm, using nsenter to execute
 // in the host's namespaces when running in a container. This allows the
@@ -50,6 +56,13 @@ func iscsiadmCmd(ctx context.Context, args ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "iscsiadm", args...)
 }
 
+func (s *NodeService) runISCSIAdm(ctx context.Context, args ...string) ([]byte, error) {
+	if s.runISCSIAdmFn != nil {
+		return s.runISCSIAdmFn(ctx, args...)
+	}
+	return iscsiadmCmd(ctx, args...).CombinedOutput()
+}
+
 // iscsiConnectionParams holds validated iSCSI connection parameters.
 type iscsiConnectionParams struct {
 	iqn    string
@@ -69,6 +82,9 @@ func (s *NodeService) stageISCSIVolume(ctx context.Context, req *csi.NodeStageVo
 	params, err := s.validateISCSIParams(volumeContext)
 	if err != nil {
 		return nil, err
+	}
+	if err := writeISCSIStagingIQN(stagingTargetPath, params.iqn); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to persist iSCSI staging metadata: %v", err)
 	}
 
 	isBlockVolume := volumeCapability.GetBlock() != nil
@@ -261,26 +277,94 @@ func (s *NodeService) loginISCSITarget(ctx context.Context, params *iscsiConnect
 
 // logoutISCSITarget logs out from an iSCSI target.
 func (s *NodeService) logoutISCSITarget(ctx context.Context, params *iscsiConnectionParams) error {
+	if s.logoutISCSITargetFn != nil {
+		return s.logoutISCSITargetFn(ctx, params)
+	}
+
 	klog.V(4).Infof("Logging out from iSCSI target: %s", params.iqn)
-	logoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
+	operationCtx, operationCancel := context.WithTimeout(ctx, 20*time.Second)
+	defer operationCancel()
+	logoutCtx, logoutCancel := context.WithTimeout(operationCtx, 15*time.Second)
+	defer logoutCancel()
 
 	// Don't specify portal - logout from target on all portals
-	cmd := iscsiadmCmd(logoutCtx, "-m", "node", "-T", params.iqn, "--logout")
-	output, err := cmd.CombinedOutput()
+	output, err := s.runISCSIAdm(logoutCtx, "-m", "node", "-T", params.iqn, "--logout")
 	if err != nil {
-		// Check if already logged out
-		alreadyLoggedOut := strings.Contains(string(output), "No matching sessions") ||
-			strings.Contains(string(output), "not found")
-		if alreadyLoggedOut {
-			klog.V(4).Infof("iSCSI target already logged out")
-			return nil
+		klog.V(4).Infof("iSCSI logout command returned an error for %s: %v, output: %s", params.iqn, err, string(output))
+	}
+
+	// iscsiadm output differs across versions and "No matching sessions" can
+	// also be returned for an incorrect IQN. Verify the exact session identity
+	// instead of trusting command text.
+	verifyErr := s.waitForISCSISessionLogout(operationCtx, params.iqn, 15*time.Second)
+	if verifyErr != nil {
+		if err != nil {
+			return fmt.Errorf("iSCSI logout command failed for %s: %w, output: %s; session verification failed: %w", params.iqn, err, string(output), verifyErr)
 		}
-		return err
+		return verifyErr
 	}
 
 	klog.V(4).Infof("Successfully logged out from iSCSI target: %s", params.iqn)
 	return nil
+}
+
+func (s *NodeService) waitForISCSISessionLogout(ctx context.Context, iqn string, timeout time.Duration) error {
+	return waitForISCSISessionLogout(ctx, iqn, timeout, 250*time.Millisecond, s.isISCSISessionPresent)
+}
+
+func waitForISCSISessionLogout(
+	ctx context.Context,
+	iqn string,
+	timeout time.Duration,
+	pollInterval time.Duration,
+	sessionPresent func(context.Context, string) (bool, error),
+) error {
+
+	logoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		present, err := sessionPresent(logoutCtx, iqn)
+		if err != nil {
+			return fmt.Errorf("failed to verify iSCSI session state for %s: %w", iqn, err)
+		}
+		if !present {
+			return nil
+		}
+
+		select {
+		case <-time.After(pollInterval):
+		case <-logoutCtx.Done():
+			return fmt.Errorf("%w for IQN %s: %w", ErrISCSILogoutTimeout, iqn, logoutCtx.Err())
+		}
+	}
+}
+
+func (s *NodeService) isISCSISessionPresent(ctx context.Context, iqn string) (bool, error) {
+	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	output, err := s.runISCSIAdm(sessionCtx, "-m", "session")
+	if err != nil {
+		lowerOutput := strings.ToLower(string(output))
+		if strings.Contains(lowerOutput, "no active sessions") ||
+			strings.Contains(lowerOutput, "no matching sessions") ||
+			strings.Contains(lowerOutput, "no records found") {
+
+			return false, nil
+		}
+		return false, fmt.Errorf("iscsiadm session query failed: %w, output: %s", err, string(output))
+	}
+	return iscsiSessionPresentInOutput(string(output), iqn), nil
+}
+
+func iscsiSessionPresentInOutput(output, iqn string) bool {
+	for _, field := range strings.Fields(output) {
+		if field == iqn {
+			return true
+		}
+	}
+	return false
 }
 
 // findISCSIDevice finds the device path for an iSCSI LUN.
@@ -500,6 +584,29 @@ func (s *NodeService) unstageISCSIVolume(ctx context.Context, req *csi.NodeUnsta
 
 	// Get IQN from volume context
 	iqn := volumeContext[VolumeContextKeyISCSIIQN]
+	if iqn == "" {
+		derivedIQN, deriveErr := s.deriveISCSIIQNFromStagingPath(ctx, stagingTargetPath)
+		if deriveErr != nil {
+			klog.Warningf("Failed to derive iSCSI IQN from staging path %s: %v", stagingTargetPath, deriveErr)
+		} else {
+			iqn = derivedIQN
+			klog.V(4).Infof("Derived iSCSI IQN from staging path %s: %s", stagingTargetPath, iqn)
+		}
+	}
+	if iqn == "" {
+		if _, statErr := os.Lstat(stagingTargetPath); os.IsNotExist(statErr) {
+			klog.V(4).Infof("Staging path %s no longer exists; iSCSI volume %s is already unstaged", stagingTargetPath, volumeID)
+			return &csi.NodeUnstageVolumeResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Internal,
+			"cannot determine IQN for iSCSI volume %s at staging path %s; refusing to report successful unstage",
+			volumeID, stagingTargetPath)
+	}
+
+	// Preserve the real IQN before unmounting so a failed logout can be retried.
+	if err := writeISCSIStagingIQN(stagingTargetPath, iqn); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to persist iSCSI staging metadata before unmount: %v", err)
+	}
 
 	// Check if mounted and unmount if necessary
 	mounted, err := mount.IsMounted(ctx, stagingTargetPath)
@@ -512,12 +619,6 @@ func (s *NodeService) unstageISCSIVolume(ctx context.Context, req *csi.NodeUnsta
 		if err := mount.Unmount(ctx, stagingTargetPath); err != nil {
 			return nil, status.Errorf(codes.Internal, "Failed to unmount staging path: %v", err)
 		}
-	}
-
-	// If we don't have IQN, we can't logout
-	if iqn == "" {
-		klog.Warningf("Cannot determine IQN for volume %s - skipping iSCSI logout", volumeID)
-		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 
 	// Logout from the iSCSI target
@@ -535,10 +636,149 @@ func (s *NodeService) unstageISCSIVolume(ctx context.Context, req *csi.NodeUnsta
 
 	klog.V(4).Infof("Logging out from iSCSI target for volume %s: IQN=%s", volumeID, iqn)
 	if err := s.logoutISCSITarget(ctx, params); err != nil {
-		klog.Warningf("Failed to logout from iSCSI target (continuing anyway): %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to logout iSCSI volume %s (IQN %s): %v", volumeID, iqn, err)
 	}
+	if err := removeISCSIBlockStagingPath(stagingTargetPath); err != nil {
+		return nil, status.Errorf(codes.Internal, "logged out iSCSI volume %s but failed to remove block staging path: %v", volumeID, err)
+	}
+	if err := removeISCSIStagingIQN(stagingTargetPath); err != nil {
+		return nil, status.Errorf(codes.Internal, "logged out iSCSI volume %s but failed to remove staging metadata: %v", volumeID, err)
+	}
+	klog.Infof("Logged out iSCSI volume %s from target %s", volumeID, iqn)
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
+}
+
+func (s *NodeService) deriveISCSIIQNFromStagingPath(ctx context.Context, stagingTargetPath string) (string, error) {
+	if iqn, err := readISCSIStagingIQN(stagingTargetPath); err == nil && iqn != "" {
+		return iqn, nil
+	} else if err != nil {
+		klog.Warningf("Failed to read iSCSI staging metadata for %s: %v; falling back to session metadata", stagingTargetPath, err)
+	}
+
+	devicePath, err := getStagedISCSIDevicePath(ctx, stagingTargetPath)
+	if err != nil {
+		return "", err
+	}
+
+	return s.findISCSIIQNForDevice(ctx, devicePath)
+}
+
+func (s *NodeService) findISCSIIQNForDevice(ctx context.Context, devicePath string) (string, error) {
+	sessionCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	output, err := s.runISCSIAdm(sessionCtx, "-m", "session", "-P", "3")
+	if err != nil {
+		return "", fmt.Errorf("failed to query iSCSI sessions: %w, output: %s", err, string(output))
+	}
+
+	iqn := parseISCSISessionIQNForDevice(string(output), filepath.Base(devicePath))
+	if iqn == "" {
+		return "", fmt.Errorf("%w for staged device %s", ErrISCSIDeviceNotFound, devicePath)
+	}
+	return iqn, nil
+}
+
+func getStagedISCSIDevicePath(ctx context.Context, stagingTargetPath string) (string, error) {
+	if mounted, err := mount.IsMounted(ctx, stagingTargetPath); err == nil && mounted {
+		cmd := exec.CommandContext(ctx, "findmnt", "-n", "-o", "SOURCE", stagingTargetPath)
+		output, cmdErr := cmd.CombinedOutput()
+		if cmdErr != nil {
+			return "", fmt.Errorf("findmnt source lookup failed for %s: %w", stagingTargetPath, cmdErr)
+		}
+		devicePath := strings.TrimSpace(string(output))
+		if strings.HasPrefix(devicePath, "/dev/") {
+			return devicePath, nil
+		}
+	}
+
+	resolved, err := filepath.EvalSymlinks(stagingTargetPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve iSCSI staging path %s: %w", stagingTargetPath, err)
+	}
+	if !strings.HasPrefix(resolved, "/dev/") {
+		return "", fmt.Errorf("%w: %s -> %s", ErrISCSINonDevicePath, stagingTargetPath, resolved)
+	}
+	return resolved, nil
+}
+
+func parseISCSISessionIQNForDevice(output, deviceName string) string {
+	deviceName = filepath.Base(deviceName)
+	currentIQN := ""
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Target:") {
+			targetFields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, "Target:")))
+			currentIQN = ""
+			if len(targetFields) > 0 {
+				currentIQN = targetFields[0]
+			}
+			continue
+		}
+		if currentIQN == "" || !strings.Contains(line, "Attached scsi disk") {
+			continue
+		}
+		fields := strings.Fields(line)
+		for i, field := range fields {
+			if field == "disk" && i+1 < len(fields) && fields[i+1] == deviceName {
+				return currentIQN
+			}
+		}
+	}
+
+	return ""
+}
+
+func iscsiStagingMetadataPath(stagingTargetPath string) string {
+	return stagingTargetPath + iscsiStagingMetadataSuffix
+}
+
+func writeISCSIStagingIQN(stagingTargetPath, iqn string) error {
+	if strings.TrimSpace(iqn) == "" {
+		return ErrISCSIEmptyIQN
+	}
+	if err := os.MkdirAll(filepath.Dir(stagingTargetPath), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(iscsiStagingMetadataPath(stagingTargetPath), []byte(iqn+"\n"), 0o600)
+}
+
+func readISCSIStagingIQN(stagingTargetPath string) (string, error) {
+	data, err := os.ReadFile(iscsiStagingMetadataPath(stagingTargetPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	iqn := strings.TrimSpace(string(data))
+	if iqn == "" {
+		return "", ErrISCSIEmptyIQN
+	}
+	return iqn, nil
+}
+
+func removeISCSIStagingIQN(stagingTargetPath string) error {
+	err := os.Remove(iscsiStagingMetadataPath(stagingTargetPath))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func removeISCSIBlockStagingPath(stagingTargetPath string) error {
+	info, err := os.Lstat(stagingTargetPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return nil
+	}
+	return os.Remove(stagingTargetPath)
 }
 
 // getISCSIMountOptions merges user-provided mount options with sensible defaults.

--- a/pkg/driver/node_iscsi.go
+++ b/pkg/driver/node_iscsi.go
@@ -33,7 +33,10 @@ var (
 // defaultISCSIMountOptions are sensible defaults for iSCSI filesystem mounts.
 var defaultISCSIMountOptions = []string{zfsNoatime, "_netdev"}
 
-const iscsiStagingMetadataSuffix = ".tns-csi-iscsi"
+const (
+	iscsiStagingMetadataSuffix = ".tns-csi-iscsi"
+	iscsiTargetPrefix          = "Target:"
+)
 
 // iscsiadmCmd builds a command to run iscsiadm, using nsenter to execute
 // in the host's namespaces when running in a container. This allows the
@@ -406,12 +409,9 @@ func parseISCSISessionDevice(output, targetIQN string) string {
 		// Check if we're entering a target section
 		// Format: "Target: iqn.2005-10.org.freenas.ctl:pvc-xxx (non-flash)"
 		// The IQN might be followed by extra text like "(non-flash)"
-		if strings.HasPrefix(line, "Target:") {
-			targetLine := strings.TrimPrefix(line, "Target:")
-			targetLine = strings.TrimSpace(targetLine)
-			// Check if this line contains our target IQN (use Contains/HasPrefix
-			// because there might be extra text after the IQN)
-			inTargetSection = strings.HasPrefix(targetLine, targetIQN)
+		if strings.HasPrefix(line, iscsiTargetPrefix) {
+			targetFields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, iscsiTargetPrefix)))
+			inTargetSection = len(targetFields) > 0 && targetFields[0] == targetIQN
 			continue
 		}
 
@@ -582,17 +582,7 @@ func (s *NodeService) unstageISCSIVolume(ctx context.Context, req *csi.NodeUnsta
 
 	klog.V(4).Infof("Unstaging iSCSI volume %s from %s", volumeID, stagingTargetPath)
 
-	// Get IQN from volume context
-	iqn := volumeContext[VolumeContextKeyISCSIIQN]
-	if iqn == "" {
-		derivedIQN, deriveErr := s.deriveISCSIIQNFromStagingPath(ctx, stagingTargetPath)
-		if deriveErr != nil {
-			klog.Warningf("Failed to derive iSCSI IQN from staging path %s: %v", stagingTargetPath, deriveErr)
-		} else {
-			iqn = derivedIQN
-			klog.V(4).Infof("Derived iSCSI IQN from staging path %s: %s", stagingTargetPath, iqn)
-		}
-	}
+	iqn := s.resolveISCSIUnstageIQN(ctx, stagingTargetPath, volumeContext)
 	if iqn == "" {
 		if _, statErr := os.Lstat(stagingTargetPath); os.IsNotExist(statErr) {
 			klog.V(4).Infof("Staging path %s no longer exists; iSCSI volume %s is already unstaged", stagingTargetPath, volumeID)
@@ -649,6 +639,20 @@ func (s *NodeService) unstageISCSIVolume(ctx context.Context, req *csi.NodeUnsta
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
+func (s *NodeService) resolveISCSIUnstageIQN(ctx context.Context, stagingTargetPath string, volumeContext map[string]string) string {
+	if iqn := volumeContext[VolumeContextKeyISCSIIQN]; iqn != "" {
+		return iqn
+	}
+
+	iqn, err := s.deriveISCSIIQNFromStagingPath(ctx, stagingTargetPath)
+	if err != nil {
+		klog.Warningf("Failed to derive iSCSI IQN from staging path %s: %v", stagingTargetPath, err)
+		return ""
+	}
+	klog.V(4).Infof("Derived iSCSI IQN from staging path %s: %s", stagingTargetPath, iqn)
+	return iqn
+}
+
 func (s *NodeService) deriveISCSIIQNFromStagingPath(ctx context.Context, stagingTargetPath string) (string, error) {
 	if iqn, err := readISCSIStagingIQN(stagingTargetPath); err == nil && iqn != "" {
 		return iqn, nil
@@ -681,7 +685,7 @@ func (s *NodeService) findISCSIIQNForDevice(ctx context.Context, devicePath stri
 
 func getStagedISCSIDevicePath(ctx context.Context, stagingTargetPath string) (string, error) {
 	if mounted, err := mount.IsMounted(ctx, stagingTargetPath); err == nil && mounted {
-		cmd := exec.CommandContext(ctx, "findmnt", "-n", "-o", "SOURCE", stagingTargetPath)
+		cmd := exec.CommandContext(ctx, "/usr/bin/findmnt", "-n", "-o", "SOURCE", stagingTargetPath)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
 			return "", fmt.Errorf("findmnt source lookup failed for %s: %w", stagingTargetPath, cmdErr)
@@ -708,8 +712,8 @@ func parseISCSISessionIQNForDevice(output, deviceName string) string {
 
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "Target:") {
-			targetFields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, "Target:")))
+		if strings.HasPrefix(line, iscsiTargetPrefix) {
+			targetFields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, iscsiTargetPrefix)))
 			currentIQN = ""
 			if len(targetFields) > 0 {
 				currentIQN = targetFields[0]

--- a/pkg/driver/node_iscsi.go
+++ b/pkg/driver/node_iscsi.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -19,15 +21,16 @@ import (
 
 // Static errors for iSCSI operations.
 var (
-	ErrISCSIAdmNotFound     = errors.New("iscsiadm command not found - please install open-iscsi")
-	ErrISCSIDeviceNotFound  = errors.New("iSCSI device not found")
-	ErrISCSIDeviceTimeout   = errors.New("timeout waiting for iSCSI device to appear")
-	ErrISCSILoginFailed     = errors.New("failed to login to iSCSI target")
-	ErrISCSIDiscoveryFailed = errors.New("iSCSI discovery failed - iscsid may not be running or accessible")
-	ErrISCSITargetNotInDB   = errors.New("iSCSI target not found in node database after discovery")
-	ErrISCSIEmptyIQN        = errors.New("empty iSCSI IQN")
-	ErrISCSILogoutTimeout   = errors.New("timeout waiting for iSCSI session logout")
-	ErrISCSINonDevicePath   = errors.New("iSCSI staging path resolved to a non-device path")
+	ErrISCSIAdmNotFound      = errors.New("iscsiadm command not found - please install open-iscsi")
+	ErrISCSIDeviceNotFound   = errors.New("iSCSI device not found")
+	ErrISCSIDeviceTimeout    = errors.New("timeout waiting for iSCSI device to appear")
+	ErrISCSILoginFailed      = errors.New("failed to login to iSCSI target")
+	ErrISCSIDiscoveryFailed  = errors.New("iSCSI discovery failed - iscsid may not be running or accessible")
+	ErrISCSITargetNotInDB    = errors.New("iSCSI target not found in node database after discovery")
+	ErrISCSIEmptyIQN         = errors.New("empty iSCSI IQN")
+	ErrISCSILogoutTimeout    = errors.New("timeout waiting for iSCSI session logout")
+	ErrISCSINonDevicePath    = errors.New("iSCSI staging path resolved to a non-device path")
+	ErrISCSIMalformedSession = errors.New("malformed iSCSI session output")
 )
 
 // defaultISCSIMountOptions are sensible defaults for iSCSI filesystem mounts.
@@ -285,65 +288,75 @@ func (s *NodeService) logoutISCSITarget(ctx context.Context, params *iscsiConnec
 	}
 
 	klog.V(4).Infof("Logging out from iSCSI target: %s", params.iqn)
-	operationCtx, operationCancel := context.WithTimeout(ctx, 20*time.Second)
+	operationCtx, operationCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer operationCancel()
-	logoutCtx, logoutCancel := context.WithTimeout(operationCtx, 15*time.Second)
-	defer logoutCancel()
 
-	// Don't specify portal - logout from target on all portals
-	output, err := s.runISCSIAdm(logoutCtx, "-m", "node", "-T", params.iqn, "--logout")
-	if err != nil {
-		klog.V(4).Infof("iSCSI logout command returned an error for %s: %v, output: %s", params.iqn, err, string(output))
-	}
-
-	// iscsiadm output differs across versions and "No matching sessions" can
-	// also be returned for an incorrect IQN. Verify the exact session identity
-	// instead of trusting command text.
-	verifyErr := s.waitForISCSISessionLogout(operationCtx, params.iqn, 15*time.Second)
-	if verifyErr != nil {
-		if err != nil {
-			return fmt.Errorf("iSCSI logout command failed for %s: %w, output: %s; session verification failed: %w", params.iqn, err, string(output), verifyErr)
-		}
-		return verifyErr
-	}
-
-	klog.V(4).Infof("Successfully logged out from iSCSI target: %s", params.iqn)
-	return nil
-}
-
-func (s *NodeService) waitForISCSISessionLogout(ctx context.Context, iqn string, timeout time.Duration) error {
-	return waitForISCSISessionLogout(ctx, iqn, timeout, 250*time.Millisecond, s.isISCSISessionPresent)
-}
-
-func waitForISCSISessionLogout(
-	ctx context.Context,
-	iqn string,
-	timeout time.Duration,
-	pollInterval time.Duration,
-	sessionPresent func(context.Context, string) (bool, error),
-) error {
-
-	logoutCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
+	var logoutErr error
 	for {
-		present, err := sessionPresent(logoutCtx, iqn)
-		if err != nil {
-			return fmt.Errorf("failed to verify iSCSI session state for %s: %w", iqn, err)
+		if operationErr := operationCtx.Err(); operationErr != nil {
+			return iscsiLogoutContextError(params.iqn, operationErr, logoutErr)
 		}
-		if !present {
+
+		sessionIDs, err := s.findISCSISessionIDs(operationCtx, params.iqn)
+		if err != nil {
+			if operationErr := operationCtx.Err(); operationErr != nil {
+				return iscsiLogoutContextError(params.iqn, operationErr, logoutErr)
+			}
+			return errors.Join(logoutErr, fmt.Errorf("failed to find active iSCSI sessions for %s: %w", params.iqn, err))
+		}
+		if len(sessionIDs) == 0 {
+			klog.V(4).Infof("Successfully logged out from iSCSI target: %s", params.iqn)
 			return nil
 		}
 
+		logoutErr = errors.Join(logoutErr, s.logoutISCSISessions(operationCtx, params.iqn, sessionIDs))
+
 		select {
-		case <-time.After(pollInterval):
-		case <-logoutCtx.Done():
-			return fmt.Errorf("%w for IQN %s: %w", ErrISCSILogoutTimeout, iqn, logoutCtx.Err())
+		case <-time.After(250 * time.Millisecond):
+		case <-operationCtx.Done():
+			return iscsiLogoutContextError(params.iqn, operationCtx.Err(), logoutErr)
 		}
 	}
 }
 
-func (s *NodeService) isISCSISessionPresent(ctx context.Context, iqn string) (bool, error) {
+func (s *NodeService) logoutISCSISessions(ctx context.Context, iqn string, sessionIDs []string) error {
+	errorsBySession := make(chan error, len(sessionIDs))
+	var waitGroup sync.WaitGroup
+	for _, sessionID := range sessionIDs {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			logoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
+			output, err := s.runISCSIAdm(logoutCtx, "-m", "session", "-r", sessionID, "--logout")
+			if err != nil {
+				klog.V(4).Infof("iSCSI logout command returned an error for %s session %s: %v, output: %s", iqn, sessionID, err, string(output))
+				errorsBySession <- fmt.Errorf("session %s: %w, output: %s", sessionID, err, string(output))
+			}
+		}()
+	}
+	waitGroup.Wait()
+	close(errorsBySession)
+
+	var logoutErr error
+	for err := range errorsBySession {
+		logoutErr = errors.Join(logoutErr, err)
+	}
+	return logoutErr
+}
+
+func iscsiLogoutContextError(iqn string, operationErr, logoutErr error) error {
+	if errors.Is(operationErr, context.Canceled) {
+		return errors.Join(logoutErr, fmt.Errorf("iSCSI logout canceled for %s: %w", iqn, operationErr))
+	}
+	timeoutErr := fmt.Errorf("%w for IQN %s: %w", ErrISCSILogoutTimeout, iqn, operationErr)
+	if logoutErr == nil {
+		return timeoutErr
+	}
+	return fmt.Errorf("iSCSI logout command failed for %s: %w; session verification failed: %w", iqn, logoutErr, timeoutErr)
+}
+
+func (s *NodeService) findISCSISessionIDs(ctx context.Context, iqn string) ([]string, error) {
 	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
@@ -354,16 +367,37 @@ func (s *NodeService) isISCSISessionPresent(ctx context.Context, iqn string) (bo
 			strings.Contains(lowerOutput, "no matching sessions") ||
 			strings.Contains(lowerOutput, "no records found") {
 
-			return false, nil
+			return nil, nil
 		}
-		return false, fmt.Errorf("iscsiadm session query failed: %w, output: %s", err, string(output))
+		return nil, fmt.Errorf("iscsiadm session query failed: %w, output: %s", err, string(output))
 	}
-	return iscsiSessionPresentInOutput(string(output), iqn), nil
+
+	return parseISCSISessionIDs(string(output), iqn)
 }
 
-func iscsiSessionPresentInOutput(output, iqn string) bool {
-	for _, field := range strings.Fields(output) {
-		if field == iqn {
+func parseISCSISessionIDs(output, targetIQN string) ([]string, error) {
+	var sessionIDs []string
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if !containsExactField(fields, targetIQN) {
+			continue
+		}
+		if len(fields) < 2 || !strings.HasPrefix(fields[1], "[") || !strings.HasSuffix(fields[1], "]") {
+			return nil, fmt.Errorf("%w for target %s: %s", ErrISCSIMalformedSession, targetIQN, line)
+		}
+
+		sessionID := strings.TrimSuffix(strings.TrimPrefix(fields[1], "["), "]")
+		if _, err := strconv.ParseUint(sessionID, 10, 64); err != nil {
+			return nil, fmt.Errorf("invalid iSCSI session ID %q for target %s: %w", sessionID, targetIQN, err)
+		}
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	return sessionIDs, nil
+}
+
+func containsExactField(fields []string, value string) bool {
+	for _, field := range fields {
+		if field == value {
 			return true
 		}
 	}

--- a/pkg/driver/node_iscsi_test.go
+++ b/pkg/driver/node_iscsi_test.go
@@ -44,6 +44,19 @@ Target: iqn.2005-10.org.freenas.ctl:pvc-test-volume-longer (non-flash)
 	}
 }
 
+func TestParseISCSISessionDeviceUsesExactIQN(t *testing.T) {
+	output := `
+Target: iqn.2005-10.org.freenas.ctl:pvc-test-volume-longer (non-flash)
+    Attached scsi disk sdb State: running
+Target: iqn.2005-10.org.freenas.ctl:pvc-test-volume (non-flash)
+    Attached scsi disk sdc State: running
+`
+
+	if got := parseISCSISessionDevice(output, testISCSIIQN); got != "sdc" {
+		t.Fatalf("parseISCSISessionDevice() = %q, want %q", got, "sdc")
+	}
+}
+
 func TestFindISCSIIQNForDeviceUsesSessionMetadata(t *testing.T) {
 	service := NewNodeService("test-node", nil, true, nil, false, 5)
 	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
@@ -56,6 +69,24 @@ func TestFindISCSIIQNForDeviceUsesSessionMetadata(t *testing.T) {
 	iqn, err := service.findISCSIIQNForDevice(context.Background(), "/dev/sdc")
 	if err != nil || iqn != testISCSIIQN {
 		t.Fatalf("findISCSIIQNForDevice() = %q, %v; want %q, nil", iqn, err, testISCSIIQN)
+	}
+}
+
+func TestFindISCSIIQNForDeviceReturnsSessionErrors(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	queryErr := errors.New("session query failed")
+	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("query output"), queryErr
+	}
+	if _, err := service.findISCSIIQNForDevice(context.Background(), "/dev/sdc"); !errors.Is(err, queryErr) {
+		t.Fatalf("findISCSIIQNForDevice() error = %v, want wrapped query error", err)
+	}
+
+	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("Target: " + testISCSIIQN + "\n    Attached scsi disk sdb State: running\n"), nil
+	}
+	if _, err := service.findISCSIIQNForDevice(context.Background(), "/dev/sdc"); !errors.Is(err, ErrISCSIDeviceNotFound) {
+		t.Fatalf("findISCSIIQNForDevice() error = %v, want ErrISCSIDeviceNotFound", err)
 	}
 }
 
@@ -110,6 +141,23 @@ func TestLogoutISCSITargetTreatsVerifiedAbsenceAsIdempotent(t *testing.T) {
 	}
 }
 
+func TestLogoutISCSITargetReportsCommandAndVerificationFailure(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	commandErr := errors.New("logout command failed")
+	queryErr := errors.New("session query failed")
+	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[1] == "node" {
+			return []byte("logout output"), commandErr
+		}
+		return []byte("query output"), queryErr
+	}
+
+	err := service.logoutISCSITarget(context.Background(), &iscsiConnectionParams{iqn: testISCSIIQN})
+	if !errors.Is(err, commandErr) || !errors.Is(err, queryErr) {
+		t.Fatalf("logoutISCSITarget() error = %v, want wrapped command and query errors", err)
+	}
+}
+
 func TestIsISCSISessionPresent(t *testing.T) {
 	service := NewNodeService("test-node", nil, true, nil, false, 5)
 	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
@@ -126,6 +174,15 @@ func TestIsISCSISessionPresent(t *testing.T) {
 	present, err = service.isISCSISessionPresent(context.Background(), testISCSIIQN)
 	if err != nil || present {
 		t.Fatalf("isISCSISessionPresent() = %v, %v; want false, nil", present, err)
+	}
+
+	queryErr := errors.New("session query failed")
+	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("unexpected output"), queryErr
+	}
+	present, err = service.isISCSISessionPresent(context.Background(), testISCSIIQN)
+	if present || !errors.Is(err, queryErr) {
+		t.Fatalf("isISCSISessionPresent() = %v, %v; want false and wrapped query error", present, err)
 	}
 }
 
@@ -209,6 +266,38 @@ func TestISCSIStagingMetadataSupportsUnstageRetry(t *testing.T) {
 	}
 	if _, statErr := os.Stat(iscsiStagingMetadataPath(stagingPath)); !os.IsNotExist(statErr) {
 		t.Fatalf("staging metadata still exists after successful unstage: %v", statErr)
+	}
+}
+
+func TestGetStagedISCSIDevicePathRecoversBlockSymlink(t *testing.T) {
+	stagingPath := filepath.Join(t.TempDir(), "globalmount")
+	if err := os.Symlink("/dev/null", stagingPath); err != nil {
+		t.Fatalf("failed to create block staging symlink: %v", err)
+	}
+
+	devicePath, err := getStagedISCSIDevicePath(context.Background(), stagingPath)
+	if err != nil || devicePath != "/dev/null" {
+		t.Fatalf("getStagedISCSIDevicePath() = %q, %v; want %q, nil", devicePath, err, "/dev/null")
+	}
+
+	nonDevicePath := t.TempDir()
+	if _, err := getStagedISCSIDevicePath(context.Background(), nonDevicePath); !errors.Is(err, ErrISCSINonDevicePath) {
+		t.Fatalf("getStagedISCSIDevicePath() error = %v, want ErrISCSINonDevicePath", err)
+	}
+}
+
+func TestInvalidISCSIStagingMetadataStillSelectsISCSI(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	stagingPath := filepath.Join(t.TempDir(), "globalmount")
+	if err := os.WriteFile(iscsiStagingMetadataPath(stagingPath), nil, 0o600); err != nil {
+		t.Fatalf("failed to write empty staging metadata: %v", err)
+	}
+
+	if _, err := readISCSIStagingIQN(stagingPath); !errors.Is(err, ErrISCSIEmptyIQN) {
+		t.Fatalf("readISCSIStagingIQN() error = %v, want ErrISCSIEmptyIQN", err)
+	}
+	if got := service.detectProtocolFromStagingPath(context.Background(), stagingPath); got != ProtocolISCSI {
+		t.Fatalf("detectProtocolFromStagingPath() = %q, want %q", got, ProtocolISCSI)
 	}
 }
 

--- a/pkg/driver/node_iscsi_test.go
+++ b/pkg/driver/node_iscsi_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -90,27 +92,42 @@ func TestFindISCSIIQNForDeviceReturnsSessionErrors(t *testing.T) {
 	}
 }
 
-func TestISCSISessionPresentInOutputUsesExactIQN(t *testing.T) {
-	output := "tcp: [5] 192.168.20.10:3260,1 " + testISCSIIQN + "-longer (non-flash)\n" +
-		"tcp: [6] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)\n"
+func TestParseISCSISessionIDsUsesExactIQN(t *testing.T) {
+	output := "tcp: [4] 192.168.20.10:3260,1 " + testISCSIIQN + "-longer (non-flash)\n" +
+		"tcp: [59] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)\n" +
+		"tcp: [61] 192.168.20.11:3260,1 " + testISCSIIQN + " (non-flash)\n"
 
-	if !iscsiSessionPresentInOutput(output, testISCSIIQN) {
-		t.Fatal("iscsiSessionPresentInOutput() did not find exact IQN")
+	sessionIDs, err := parseISCSISessionIDs(output, testISCSIIQN)
+	if err != nil {
+		t.Fatalf("parseISCSISessionIDs() unexpected error: %v", err)
 	}
-	if iscsiSessionPresentInOutput(output, "iqn.2005-10.org.freenas.ctl:pvc-test") {
-		t.Fatal("iscsiSessionPresentInOutput() matched a partial IQN")
+	if len(sessionIDs) != 2 || sessionIDs[0] != "59" || sessionIDs[1] != "61" {
+		t.Fatalf("parseISCSISessionIDs() = %v, want [59 61]", sessionIDs)
+	}
+}
+
+func TestParseISCSISessionIDsRejectsInvalidSID(t *testing.T) {
+	output := "tcp: [invalid] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)"
+	if _, err := parseISCSISessionIDs(output, testISCSIIQN); !errors.Is(err, strconv.ErrSyntax) {
+		t.Fatalf("parseISCSISessionIDs() error = %v, want strconv.ErrSyntax", err)
 	}
 }
 
 func TestLogoutISCSITargetVerifiesExactSessionRemoval(t *testing.T) {
 	service := NewNodeService("test-node", nil, true, nil, false, 5)
-	commands := 0
+	var commands atomic.Int32
 	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
-		commands++
-		if len(args) >= 2 && args[0] == "-m" && args[1] == "node" {
-			return []byte("Logout of session successful"), nil
+		command := commands.Add(1)
+		if len(args) == 5 && args[0] == "-m" && args[1] == "session" && args[2] == "-r" && args[4] == "--logout" {
+			if args[3] == "59" || args[3] == "61" {
+				return []byte("Logout of session successful"), nil
+			}
 		}
-		if len(args) >= 2 && args[0] == "-m" && args[1] == "session" {
+		if len(args) == 2 && args[0] == "-m" && args[1] == "session" && command == 1 {
+			return []byte("tcp: [59] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)\n" +
+				"tcp: [61] 192.168.20.11:3260,1 " + testISCSIIQN + " (non-flash)"), nil
+		}
+		if len(args) == 2 && args[0] == "-m" && args[1] == "session" {
 			return []byte("tcp: [4] 192.168.20.10:3260,1 iqn.2005-10.org.freenas.ctl:pvc-other (non-flash)"), nil
 		}
 		t.Fatalf("unexpected iscsiadm arguments: %v", args)
@@ -121,8 +138,114 @@ func TestLogoutISCSITargetVerifiesExactSessionRemoval(t *testing.T) {
 	if err != nil {
 		t.Fatalf("logoutISCSITarget() unexpected error: %v", err)
 	}
-	if commands != 2 {
-		t.Fatalf("iscsiadm commands = %d, want 2", commands)
+	if commands.Load() != 4 {
+		t.Fatalf("iscsiadm commands = %d, want 4", commands.Load())
+	}
+}
+
+func TestLogoutISCSISessionsRunsConcurrently(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
+		started <- args[3]
+		<-release
+		return []byte("Logout successful"), nil
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- service.logoutISCSISessions(context.Background(), testISCSIIQN, []string{"59", "61"})
+	}()
+
+	seen := map[string]bool{}
+	for range 2 {
+		select {
+		case sessionID := <-started:
+			seen[sessionID] = true
+		case <-time.After(time.Second):
+			t.Fatal("session logout commands did not start concurrently")
+		}
+	}
+	close(release)
+	if err := <-result; err != nil {
+		t.Fatalf("logoutISCSISessions() unexpected error: %v", err)
+	}
+	if !seen["59"] || !seen["61"] {
+		t.Fatalf("started session logouts = %v, want 59 and 61", seen)
+	}
+}
+
+func TestLogoutISCSITargetUsesLiveSessionWithoutNodeRecords(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	sessionPresent := true
+	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) == 2 && args[0] == "-m" && args[1] == "session" {
+			if sessionPresent {
+				return []byte("tcp: [59] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)"), nil
+			}
+			return []byte("No active sessions."), errors.New("exit status 21")
+		}
+		if len(args) == 5 && args[0] == "-m" && args[1] == "session" && args[2] == "-r" && args[3] == "59" && args[4] == "--logout" {
+			sessionPresent = false
+			return []byte("Logout of session [sid: 59] successful."), nil
+		}
+		t.Fatalf("unexpected iscsiadm arguments: %v", args)
+		return nil, nil
+	}
+
+	if err := service.logoutISCSITarget(context.Background(), &iscsiConnectionParams{iqn: testISCSIIQN}); err != nil {
+		t.Fatalf("logoutISCSITarget() unexpected error: %v", err)
+	}
+}
+
+func TestLogoutISCSITargetReenumeratesLiveSessions(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	queries := 0
+	var loggedOut []string
+	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) == 2 {
+			queries++
+			switch queries {
+			case 1:
+				return []byte("tcp: [59] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)"), nil
+			case 2:
+				return []byte("tcp: [60] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)"), nil
+			default:
+				return []byte("No active sessions."), errors.New("exit status 21")
+			}
+		}
+		if len(args) == 5 && args[0] == "-m" && args[1] == "session" && args[2] == "-r" && args[4] == "--logout" {
+			loggedOut = append(loggedOut, args[3])
+			return []byte("Logout successful"), nil
+		}
+		t.Fatalf("unexpected iscsiadm arguments: %v", args)
+		return nil, nil
+	}
+
+	if err := service.logoutISCSITarget(context.Background(), &iscsiConnectionParams{iqn: testISCSIIQN}); err != nil {
+		t.Fatalf("logoutISCSITarget() unexpected error: %v", err)
+	}
+	if len(loggedOut) != 2 || loggedOut[0] != "59" || loggedOut[1] != "60" {
+		t.Fatalf("logged out sessions = %v, want [59 60]", loggedOut)
+	}
+}
+
+func TestLogoutISCSITargetReportsTimeout(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := service.logoutISCSITarget(canceledCtx, &iscsiConnectionParams{iqn: testISCSIIQN})
+	if !errors.Is(err, context.Canceled) || errors.Is(err, ErrISCSILogoutTimeout) {
+		t.Fatalf("logoutISCSITarget() cancellation error = %v, want context.Canceled only", err)
+	}
+
+	deadlineCtx, deadlineCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer deadlineCancel()
+	err = service.logoutISCSITarget(deadlineCtx, &iscsiConnectionParams{iqn: testISCSIIQN})
+	if !errors.Is(err, ErrISCSILogoutTimeout) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("logoutISCSITarget() deadline error = %v, want logout timeout wrapping deadline", err)
 	}
 }
 
@@ -130,10 +253,11 @@ func TestLogoutISCSITargetTreatsVerifiedAbsenceAsIdempotent(t *testing.T) {
 	service := NewNodeService("test-node", nil, true, nil, false, 5)
 	commandErr := errors.New("exit status 21")
 	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
-		if len(args) >= 2 && args[1] == "node" {
-			return []byte("No matching sessions found"), commandErr
+		if len(args) == 2 {
+			return []byte("No active sessions."), commandErr
 		}
-		return []byte("No active sessions."), commandErr
+		t.Fatalf("unexpected iscsiadm arguments: %v", args)
+		return nil, nil
 	}
 
 	if err := service.logoutISCSITarget(context.Background(), &iscsiConnectionParams{iqn: testISCSIIQN}); err != nil {
@@ -145,9 +269,14 @@ func TestLogoutISCSITargetReportsCommandAndVerificationFailure(t *testing.T) {
 	service := NewNodeService("test-node", nil, true, nil, false, 5)
 	commandErr := errors.New("logout command failed")
 	queryErr := errors.New("session query failed")
+	queries := 0
 	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
-		if len(args) >= 2 && args[1] == "node" {
+		if len(args) == 5 {
 			return []byte("logout output"), commandErr
+		}
+		queries++
+		if queries == 1 {
+			return []byte("tcp: [59] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)"), nil
 		}
 		return []byte("query output"), queryErr
 	}
@@ -155,84 +284,6 @@ func TestLogoutISCSITargetReportsCommandAndVerificationFailure(t *testing.T) {
 	err := service.logoutISCSITarget(context.Background(), &iscsiConnectionParams{iqn: testISCSIIQN})
 	if !errors.Is(err, commandErr) || !errors.Is(err, queryErr) {
 		t.Fatalf("logoutISCSITarget() error = %v, want wrapped command and query errors", err)
-	}
-}
-
-func TestIsISCSISessionPresent(t *testing.T) {
-	service := NewNodeService("test-node", nil, true, nil, false, 5)
-	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
-		return []byte("tcp: [5] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)"), nil
-	}
-	present, err := service.isISCSISessionPresent(context.Background(), testISCSIIQN)
-	if err != nil || !present {
-		t.Fatalf("isISCSISessionPresent() = %v, %v; want true, nil", present, err)
-	}
-
-	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
-		return []byte("No active sessions."), errors.New("exit status 21")
-	}
-	present, err = service.isISCSISessionPresent(context.Background(), testISCSIIQN)
-	if err != nil || present {
-		t.Fatalf("isISCSISessionPresent() = %v, %v; want false, nil", present, err)
-	}
-
-	queryErr := errors.New("session query failed")
-	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
-		return []byte("unexpected output"), queryErr
-	}
-	present, err = service.isISCSISessionPresent(context.Background(), testISCSIIQN)
-	if present || !errors.Is(err, queryErr) {
-		t.Fatalf("isISCSISessionPresent() = %v, %v; want false and wrapped query error", present, err)
-	}
-}
-
-func TestWaitForISCSISessionLogout(t *testing.T) {
-	checks := 0
-	err := waitForISCSISessionLogout(
-		context.Background(),
-		testISCSIIQN,
-		time.Second,
-		time.Millisecond,
-		func(_ context.Context, iqn string) (bool, error) {
-			if iqn != testISCSIIQN {
-				t.Fatalf("session check IQN = %q, want %q", iqn, testISCSIIQN)
-			}
-			checks++
-			return checks < 3, nil
-		},
-	)
-	if err != nil {
-		t.Fatalf("waitForISCSISessionLogout() unexpected error: %v", err)
-	}
-	if checks != 3 {
-		t.Fatalf("session checks = %d, want 3", checks)
-	}
-}
-
-func TestWaitForISCSISessionLogoutTimesOut(t *testing.T) {
-	err := waitForISCSISessionLogout(
-		context.Background(),
-		testISCSIIQN,
-		20*time.Millisecond,
-		5*time.Millisecond,
-		func(_ context.Context, _ string) (bool, error) { return true, nil },
-	)
-	if !errors.Is(err, ErrISCSILogoutTimeout) {
-		t.Fatalf("waitForISCSISessionLogout() error = %v, want ErrISCSILogoutTimeout", err)
-	}
-}
-
-func TestWaitForISCSISessionLogoutReturnsQueryError(t *testing.T) {
-	queryErr := errors.New("session query failed")
-	err := waitForISCSISessionLogout(
-		context.Background(),
-		testISCSIIQN,
-		time.Second,
-		time.Millisecond,
-		func(_ context.Context, _ string) (bool, error) { return false, queryErr },
-	)
-	if !errors.Is(err, queryErr) {
-		t.Fatalf("waitForISCSISessionLogout() error = %v, want wrapped query error", err)
 	}
 }
 

--- a/pkg/driver/node_iscsi_test.go
+++ b/pkg/driver/node_iscsi_test.go
@@ -1,0 +1,290 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const testISCSIIQN = "iqn.2005-10.org.freenas.ctl:pvc-test-volume"
+
+func TestParseISCSISessionIQNForDevice(t *testing.T) {
+	output := `
+Target: iqn.2005-10.org.freenas.ctl:pvc-other (non-flash)
+    Attached scsi disk sdb          State: running
+Target: iqn.2005-10.org.freenas.ctl:pvc-test-volume (non-flash)
+    Attached scsi disk sdc          State: running
+Target: iqn.2005-10.org.freenas.ctl:pvc-test-volume-longer (non-flash)
+    Attached scsi disk sdd          State: running
+`
+
+	tests := []struct {
+		device string
+		want   string
+	}{
+		{device: "sdb", want: "iqn.2005-10.org.freenas.ctl:pvc-other"},
+		{device: "/dev/sdc", want: testISCSIIQN},
+		{device: "sdd", want: "iqn.2005-10.org.freenas.ctl:pvc-test-volume-longer"},
+		{device: "sde", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.device, func(t *testing.T) {
+			if got := parseISCSISessionIQNForDevice(output, tt.device); got != tt.want {
+				t.Fatalf("parseISCSISessionIQNForDevice() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindISCSIIQNForDeviceUsesSessionMetadata(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) != 4 || args[0] != "-m" || args[1] != "session" || args[2] != "-P" || args[3] != "3" {
+			t.Fatalf("unexpected iscsiadm arguments: %v", args)
+		}
+		return []byte("Target: " + testISCSIIQN + " (non-flash)\n    Attached scsi disk sdc State: running\n"), nil
+	}
+
+	iqn, err := service.findISCSIIQNForDevice(context.Background(), "/dev/sdc")
+	if err != nil || iqn != testISCSIIQN {
+		t.Fatalf("findISCSIIQNForDevice() = %q, %v; want %q, nil", iqn, err, testISCSIIQN)
+	}
+}
+
+func TestISCSISessionPresentInOutputUsesExactIQN(t *testing.T) {
+	output := "tcp: [5] 192.168.20.10:3260,1 " + testISCSIIQN + "-longer (non-flash)\n" +
+		"tcp: [6] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)\n"
+
+	if !iscsiSessionPresentInOutput(output, testISCSIIQN) {
+		t.Fatal("iscsiSessionPresentInOutput() did not find exact IQN")
+	}
+	if iscsiSessionPresentInOutput(output, "iqn.2005-10.org.freenas.ctl:pvc-test") {
+		t.Fatal("iscsiSessionPresentInOutput() matched a partial IQN")
+	}
+}
+
+func TestLogoutISCSITargetVerifiesExactSessionRemoval(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	commands := 0
+	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
+		commands++
+		if len(args) >= 2 && args[0] == "-m" && args[1] == "node" {
+			return []byte("Logout of session successful"), nil
+		}
+		if len(args) >= 2 && args[0] == "-m" && args[1] == "session" {
+			return []byte("tcp: [4] 192.168.20.10:3260,1 iqn.2005-10.org.freenas.ctl:pvc-other (non-flash)"), nil
+		}
+		t.Fatalf("unexpected iscsiadm arguments: %v", args)
+		return nil, nil
+	}
+
+	err := service.logoutISCSITarget(context.Background(), &iscsiConnectionParams{iqn: testISCSIIQN})
+	if err != nil {
+		t.Fatalf("logoutISCSITarget() unexpected error: %v", err)
+	}
+	if commands != 2 {
+		t.Fatalf("iscsiadm commands = %d, want 2", commands)
+	}
+}
+
+func TestLogoutISCSITargetTreatsVerifiedAbsenceAsIdempotent(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	commandErr := errors.New("exit status 21")
+	service.runISCSIAdmFn = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[1] == "node" {
+			return []byte("No matching sessions found"), commandErr
+		}
+		return []byte("No active sessions."), commandErr
+	}
+
+	if err := service.logoutISCSITarget(context.Background(), &iscsiConnectionParams{iqn: testISCSIIQN}); err != nil {
+		t.Fatalf("logoutISCSITarget() should accept verified session absence: %v", err)
+	}
+}
+
+func TestIsISCSISessionPresent(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("tcp: [5] 192.168.20.10:3260,1 " + testISCSIIQN + " (non-flash)"), nil
+	}
+	present, err := service.isISCSISessionPresent(context.Background(), testISCSIIQN)
+	if err != nil || !present {
+		t.Fatalf("isISCSISessionPresent() = %v, %v; want true, nil", present, err)
+	}
+
+	service.runISCSIAdmFn = func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("No active sessions."), errors.New("exit status 21")
+	}
+	present, err = service.isISCSISessionPresent(context.Background(), testISCSIIQN)
+	if err != nil || present {
+		t.Fatalf("isISCSISessionPresent() = %v, %v; want false, nil", present, err)
+	}
+}
+
+func TestWaitForISCSISessionLogout(t *testing.T) {
+	checks := 0
+	err := waitForISCSISessionLogout(
+		context.Background(),
+		testISCSIIQN,
+		time.Second,
+		time.Millisecond,
+		func(_ context.Context, iqn string) (bool, error) {
+			if iqn != testISCSIIQN {
+				t.Fatalf("session check IQN = %q, want %q", iqn, testISCSIIQN)
+			}
+			checks++
+			return checks < 3, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("waitForISCSISessionLogout() unexpected error: %v", err)
+	}
+	if checks != 3 {
+		t.Fatalf("session checks = %d, want 3", checks)
+	}
+}
+
+func TestWaitForISCSISessionLogoutTimesOut(t *testing.T) {
+	err := waitForISCSISessionLogout(
+		context.Background(),
+		testISCSIIQN,
+		20*time.Millisecond,
+		5*time.Millisecond,
+		func(_ context.Context, _ string) (bool, error) { return true, nil },
+	)
+	if !errors.Is(err, ErrISCSILogoutTimeout) {
+		t.Fatalf("waitForISCSISessionLogout() error = %v, want ErrISCSILogoutTimeout", err)
+	}
+}
+
+func TestWaitForISCSISessionLogoutReturnsQueryError(t *testing.T) {
+	queryErr := errors.New("session query failed")
+	err := waitForISCSISessionLogout(
+		context.Background(),
+		testISCSIIQN,
+		time.Second,
+		time.Millisecond,
+		func(_ context.Context, _ string) (bool, error) { return false, queryErr },
+	)
+	if !errors.Is(err, queryErr) {
+		t.Fatalf("waitForISCSISessionLogout() error = %v, want wrapped query error", err)
+	}
+}
+
+func TestISCSIStagingMetadataSupportsUnstageRetry(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	stagingPath := filepath.Join(t.TempDir(), "globalmount")
+	if err := writeISCSIStagingIQN(stagingPath, testISCSIIQN); err != nil {
+		t.Fatalf("writeISCSIStagingIQN() unexpected error: %v", err)
+	}
+
+	if got := service.detectProtocolFromStagingPath(context.Background(), stagingPath); got != ProtocolISCSI {
+		t.Fatalf("detectProtocolFromStagingPath() = %q, want %q", got, ProtocolISCSI)
+	}
+	derived, err := service.deriveISCSIIQNFromStagingPath(context.Background(), stagingPath)
+	if err != nil || derived != testISCSIIQN {
+		t.Fatalf("deriveISCSIIQNFromStagingPath() = %q, %v; want %q, nil", derived, err, testISCSIIQN)
+	}
+
+	service.logoutISCSITargetFn = func(_ context.Context, params *iscsiConnectionParams) error {
+		if params.iqn != testISCSIIQN {
+			t.Errorf("logout IQN = %q, want %q", params.iqn, testISCSIIQN)
+		}
+		return nil
+	}
+	resp, err := service.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "tank/volumes/test-volume",
+		StagingTargetPath: stagingPath,
+	})
+	if err != nil || resp == nil {
+		t.Fatalf("NodeUnstageVolume() = %#v, %v; want non-nil response, nil", resp, err)
+	}
+	if _, statErr := os.Stat(iscsiStagingMetadataPath(stagingPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("staging metadata still exists after successful unstage: %v", statErr)
+	}
+}
+
+func TestISCSIRawBlockUnstageIsIdempotent(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	stagingPath := filepath.Join(t.TempDir(), "globalmount")
+	if err := os.Symlink("/dev/sdc", stagingPath); err != nil {
+		t.Fatalf("failed to create block staging symlink: %v", err)
+	}
+	if err := writeISCSIStagingIQN(stagingPath, testISCSIIQN); err != nil {
+		t.Fatalf("writeISCSIStagingIQN() unexpected error: %v", err)
+	}
+
+	logoutCalls := 0
+	service.logoutISCSITargetFn = func(_ context.Context, params *iscsiConnectionParams) error {
+		logoutCalls++
+		if params.iqn != testISCSIIQN {
+			t.Errorf("logout IQN = %q, want %q", params.iqn, testISCSIIQN)
+		}
+		return nil
+	}
+	req := &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "tank/volumes/test-volume",
+		StagingTargetPath: stagingPath,
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		resp, err := service.NodeUnstageVolume(context.Background(), req)
+		if err != nil || resp == nil {
+			t.Fatalf("NodeUnstageVolume() attempt %d = %#v, %v; want non-nil response, nil", attempt, resp, err)
+		}
+	}
+	if logoutCalls != 1 {
+		t.Fatalf("logout calls = %d, want 1", logoutCalls)
+	}
+	if _, err := os.Lstat(stagingPath); !os.IsNotExist(err) {
+		t.Fatalf("raw block staging symlink still exists after unstage: %v", err)
+	}
+}
+
+func TestUnstageISCSIVolumeReturnsLogoutFailure(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	stagingPath := filepath.Join(t.TempDir(), "globalmount")
+	if err := writeISCSIStagingIQN(stagingPath, testISCSIIQN); err != nil {
+		t.Fatalf("writeISCSIStagingIQN() unexpected error: %v", err)
+	}
+	service.logoutISCSITargetFn = func(_ context.Context, _ *iscsiConnectionParams) error {
+		return errors.New("logout failed")
+	}
+
+	resp, err := service.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "tank/volumes/test-volume",
+		StagingTargetPath: stagingPath,
+	})
+	if resp != nil {
+		t.Fatalf("NodeUnstageVolume() response = %#v, want nil", resp)
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("NodeUnstageVolume() code = %s, want %s (error: %v)", status.Code(err), codes.Internal, err)
+	}
+	if got, readErr := readISCSIStagingIQN(stagingPath); readErr != nil || got != testISCSIIQN {
+		t.Fatalf("staging metadata after failed logout = %q, %v", got, readErr)
+	}
+}
+
+func TestUnstageISCSIVolumeRejectsUnknownIQN(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	stagingPath := t.TempDir()
+
+	resp, err := service.unstageISCSIVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "tank/volumes/test-volume",
+		StagingTargetPath: stagingPath,
+	}, nil)
+	if resp != nil {
+		t.Fatalf("unstageISCSIVolume() response = %#v, want nil", resp)
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("unstageISCSIVolume() code = %s, want %s (error: %v)", status.Code(err), codes.Internal, err)
+	}
+}


### PR DESCRIPTION
## Summary

- remove the synthesized iSCSI IQN from `NodeUnstageVolume` and persist the controller-provided IQN beside the staging path
- recover the real IQN for pre-upgrade staged volumes by mapping the staged device back to exact `iscsiadm -m session -P 3` metadata
- retain staging metadata across failed unstage attempts and return logout or identity failures to kubelet for retry
- verify the exact IQN disappears from active sessions before reporting success
- remove raw-block staging symlinks before metadata cleanup so repeated unstage calls remain idempotent
- add regression coverage for exact identity, command errors, logout timeout, retry behavior, and duplicate raw-block unstage

## Testing

- `go test -race -short ./pkg/driver/...`
- `go test -short ./pkg/... ./cmd/kubectl-tns-csi/...`
- `golangci-lint run --config .golangci.yml ./...`
- `go build ./cmd/tns-csi-driver ./cmd/kubectl-tns-csi`

## Validation

Real iSCSI session cleanup should be validated on an affected node, including first unstage after upgrading a volume that has no persisted metadata yet.

Fixes #209