### PR TITLE
fix(nvmeof): parse host-grouped subsystem output

### DIFF
--- a/pkg/driver/node_nvmeof_discovery.go
+++ b/pkg/driver/node_nvmeof_discovery.go
@@ -63,14 +63,38 @@ func (s nvmeListSubsystem) nqn() string {
 	return s.NQN
 }
 
+var errInvalidNVMeListSubsystemsOutput = errors.New("invalid nvme list-subsys output")
+
 func findNVMeSubsystem(output []byte, nqn string) (*nvmeListSubsystem, error) {
-	var parsed nvmeListSubsystemsOutput
-	if err := json.Unmarshal(output, &parsed); err != nil {
-		return nil, err
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil, errInvalidNVMeListSubsystemsOutput
 	}
-	for i := range parsed.Subsystems {
-		if parsed.Subsystems[i].nqn() == nqn {
-			return &parsed.Subsystems[i], nil
+
+	var groups []nvmeListSubsystemsOutput
+	switch trimmed[0] {
+	case '[':
+		// nvme-cli 2.x groups subsystems by host in a top-level array.
+		if err := json.Unmarshal([]byte(trimmed), &groups); err != nil {
+			return nil, err
+		}
+	case '{':
+		// Older nvme-cli versions return the subsystem collection directly.
+		var parsed nvmeListSubsystemsOutput
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			return nil, err
+		}
+		groups = append(groups, parsed)
+	default:
+		return nil, fmt.Errorf("%w: unexpected JSON prefix %q", errInvalidNVMeListSubsystemsOutput, trimmed[0])
+	}
+
+	for groupIndex := range groups {
+		for subsystemIndex := range groups[groupIndex].Subsystems {
+			subsystem := &groups[groupIndex].Subsystems[subsystemIndex]
+			if subsystem.nqn() == nqn {
+				return subsystem, nil
+			}
 		}
 	}
 	return nil, nil //nolint:nilnil // nil means the exact NQN was not found

--- a/pkg/driver/node_nvmeof_test.go
+++ b/pkg/driver/node_nvmeof_test.go
@@ -51,6 +51,34 @@ func TestParseNVMeListSubsysOutputSupportsNQNField(t *testing.T) {
 	}
 }
 
+func TestParseNVMeListSubsysOutputSupportsHostArray(t *testing.T) {
+	service := NewNodeService("test-node", nil, true, nil, false, 5)
+	output := []byte(`[
+  {
+    "HostNQN": "nqn.2014-08.org.nvmexpress:uuid:test-host",
+    "HostID": "11f02066-71f9-44c9-a4b3-42daf10c0d1e",
+    "Subsystems": [{
+      "Name": "nvme-subsys4",
+      "NQN": "nqn.2026-02.csi.tns:volume",
+      "IOPolicy": "numa",
+      "Paths": [{"Name": "nvme4", "State": "live"}]
+    }]
+  }
+]`)
+
+	const nqn = "nqn.2026-02.csi.tns:volume"
+	if got := service.parseNVMeListSubsysOutputForNQN(output, nqn); got != "/dev/nvme4n1" {
+		t.Fatalf("parseNVMeListSubsysOutputForNQN() = %q, want %q", got, "/dev/nvme4n1")
+	}
+	if got := service.findControllerForNQN(string(output), nqn); got != "nvme4" {
+		t.Fatalf("findControllerForNQN() = %q, want %q", got, "nvme4")
+	}
+	subsystem, err := findNVMeSubsystem(output, nqn)
+	if err != nil || subsystem == nil || len(subsystem.Paths) != 1 || subsystem.Paths[0].State != nvmeSubsystemStateLive {
+		t.Fatalf("findNVMeSubsystem() = %#v, %v; want one live path", subsystem, err)
+	}
+}
+
 func TestNVMeNQNPresentUsesExactIdentity(t *testing.T) {
 	sysClassPath := t.TempDir()
 	writeTestSubsystemNQN(t, sysClassPath, "nvme4", "nqn.2026-02.csi.tns:volume-longer")


### PR DESCRIPTION
## Summary

- parse the host-grouped `nvme list-subsys -o json` schema emitted by `nvme-cli` 2.x
- retain support for the older top-level `Subsystems` object
- cover state and controller discovery with an Ubuntu Noble-compatible fixture

## Root cause

The parser introduced in #206 expected a top-level JSON object. The Ubuntu Noble integration VM uses `nvme-cli` 2.8, which emits a top-level array of hosts containing nested `Subsystems`. As a result, the kernel connected each requested NQN successfully, but the driver observed an empty subsystem state and exhausted the CSI staging deadline. This caused the NVMe-oF job in https://github.com/fenio/tns-csi/actions/runs/31202142167/job/92947957784 to run until its two-hour timeout.

## Verification

- `go test ./pkg/driver -run TestParseNVMeListSubsysOutput -count=1`
- `go test -short ./pkg/...`
- `go test -race ./pkg/driver`
- `golangci-lint run --config .golangci.yml ./...`
- `go build ./cmd/...`