### PR TITLE
fix(tnsapi): recover authentication on live sessions

### DIFF
--- a/pkg/tnsapi/client.go
+++ b/pkg/tnsapi/client.go
@@ -24,6 +24,10 @@ import (
 const (
 	methodAuthLoginWithAPIKey = "auth.login_with_api_key" //nolint:gosec // API method name, not a credential
 
+	// errNameNotAuthenticated is reported by the storage API when the
+	// WebSocket session is not (or no longer) authenticated.
+	errNameNotAuthenticated = "ENOTAUTHENTICATED"
+
 	filterFieldName = "name"
 	filterFieldPath = "path"
 
@@ -89,6 +93,12 @@ type Client struct {
 	closed        bool
 	reconnecting  bool
 	skipTLSVerify bool // Skip TLS certificate verification
+
+	// reauthMu serializes session re-authentication after ENOTAUTHENTICATED;
+	// lastReauthAt lets concurrent failing calls reuse a just-completed re-auth
+	// instead of each performing its own.
+	reauthMu     sync.Mutex
+	lastReauthAt time.Time
 }
 
 // Request represents a storage API WebSocket request (JSON-RPC 2.0 format).
@@ -423,6 +433,44 @@ func (c *Client) authenticateDirect() error {
 	return nil
 }
 
+// isSessionAuthError reports whether err is an ENOTAUTHENTICATED error from
+// the storage API — the WebSocket session lost its authentication while the
+// connection itself stayed alive (observed after storage middleware restarts:
+// protocol-level pings keep succeeding, so reconnect() never fires, yet every
+// RPC fails). Unlike isAuthenticationError (permanent failures such as an
+// invalid API key), this condition is recoverable by re-authenticating on the
+// live connection.
+func isSessionAuthError(err error) bool {
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.ErrorName == errNameNotAuthenticated {
+		return true
+	}
+	return apiErr.Data != nil && apiErr.Data.ErrorName == errNameNotAuthenticated
+}
+
+// reauthenticate restores session authentication on the live connection after
+// an ENOTAUTHENTICATED response. Serialized so that many concurrent calls
+// failing at once trigger a single auth.login_with_api_key: callers that
+// arrive right after a completed re-authentication reuse its result.
+func (c *Client) reauthenticate() error {
+	c.reauthMu.Lock()
+	defer c.reauthMu.Unlock()
+
+	// Another caller has just re-authenticated this session — reuse it.
+	if time.Since(c.lastReauthAt) < time.Second {
+		return nil
+	}
+
+	if err := c.authenticate(); err != nil {
+		return err
+	}
+	c.lastReauthAt = time.Now()
+	return nil
+}
+
 // isConnectionError checks if the error is a connection-related error that should trigger a retry.
 func isConnectionError(err error) bool {
 	if err == nil {
@@ -456,6 +504,21 @@ func (c *Client) Call(ctx context.Context, method string, params []interface{}, 
 		}
 
 		lastErr = err
+
+		// Session-level auth loss: the storage system dropped our session
+		// without closing the WebSocket, so the connection looks healthy and
+		// reconnect() never fires — without re-authentication every call
+		// would fail with ENOTAUTHENTICATED forever. Re-authenticate on the
+		// live connection and retry. The auth call itself is excluded to
+		// avoid recursion.
+		if method != methodAuthLoginWithAPIKey && isSessionAuthError(err) {
+			klog.Warningf("Request %s failed with %s on a live connection (attempt %d/%d), re-authenticating...",
+				method, errNameNotAuthenticated, attempt, maxRetries)
+			if raErr := c.reauthenticate(); raErr != nil {
+				return fmt.Errorf("re-authentication after %s failed: %w", errNameNotAuthenticated, raErr)
+			}
+			continue
+		}
 
 		// Check if this is a retryable connection error
 		if !isConnectionError(err) {

--- a/pkg/tnsapi/client.go
+++ b/pkg/tnsapi/client.go
@@ -522,34 +522,44 @@ func (c *Client) reauthenticate(ctx context.Context, requestEpoch uint64) error 
 		c.reauthDone = reauthDone
 		c.reauthMu.Unlock()
 
-		err := c.acquireAuthentication(ctx)
-		performedAuth := false
-		if err == nil {
-			c.reauthMu.Lock()
-			if c.reauthEpoch != requestEpoch {
-				err = c.lastReauthErr
-			} else {
-				performedAuth = true
-			}
-			c.reauthMu.Unlock()
-			if performedAuth {
-				err = c.authenticateLocked(ctx)
-			}
-			c.releaseAuthentication()
-		}
-
-		c.reauthMu.Lock()
-		// Do not make one caller's cancellation the shared result for callers
-		// that still have time to perform authentication themselves.
-		if performedAuth && ctx.Err() == nil && !isConnectionError(err) {
-			c.reauthEpoch++
-			c.lastReauthErr = err
-		}
-		c.reauthDone = nil
-		close(reauthDone)
-		c.reauthMu.Unlock()
+		performedAuth, err := c.performReauthentication(ctx, requestEpoch)
+		c.finishReauthentication(ctx, reauthDone, err, performedAuth)
 		return err
 	}
+}
+
+func (c *Client) performReauthentication(ctx context.Context, requestEpoch uint64) (bool, error) {
+	if err := c.acquireAuthentication(ctx); err != nil {
+		return false, err
+	}
+	defer c.releaseAuthentication()
+
+	c.reauthMu.Lock()
+	defer c.reauthMu.Unlock()
+	if c.reauthEpoch != requestEpoch {
+		return false, c.lastReauthErr
+	}
+
+	// Authentication dispatch also takes reauthMu, preventing regular RPCs
+	// from capturing the old epoch while the authentication request is sent.
+	c.reauthMu.Unlock()
+	err := c.authenticateLocked(ctx)
+	c.reauthMu.Lock()
+	return true, err
+}
+
+func (c *Client) finishReauthentication(ctx context.Context, done chan struct{}, err error, performedAuth bool) {
+	c.reauthMu.Lock()
+	defer c.reauthMu.Unlock()
+
+	// Do not make one caller's cancellation the shared result for callers
+	// that still have time to perform authentication themselves.
+	if performedAuth && ctx.Err() == nil && !isConnectionError(err) {
+		c.reauthEpoch++
+		c.lastReauthErr = err
+	}
+	c.reauthDone = nil
+	close(done)
 }
 
 func (c *Client) currentReauthEpoch() uint64 {
@@ -598,72 +608,102 @@ func (c *Client) Call(ctx context.Context, method string, params []interface{}, 
 		}
 
 		lastErr = err
-
-		// Session-level auth loss: the storage system dropped our session
-		// without closing the WebSocket, so the connection looks healthy and
-		// reconnect() never fires — without re-authentication every call
-		// would fail with ENOTAUTHENTICATED forever. Re-authenticate on the
-		// live connection and retry. The auth call itself is excluded to
-		// avoid recursion.
-		if method != methodAuthLoginWithAPIKey && isSessionAuthError(err) {
-			if attempt == maxRetries {
-				break
-			}
-			klog.Warningf("Request %s failed with %s on a live connection (attempt %d/%d), re-authenticating...",
-				method, errNameNotAuthenticated, attempt, maxRetries)
-			if raErr := c.reauthenticate(ctx, requestEpoch); raErr != nil {
-				if isConnectionError(raErr) {
-					lastErr = raErr
-					continue
-				}
-				return fmt.Errorf("re-authentication after %s failed: %w", errNameNotAuthenticated, raErr)
-			}
-			continue
+		retryErr, retry, terminalErr := c.prepareCallRetry(ctx, method, attempt, maxRetries, requestEpoch, err)
+		if terminalErr != nil {
+			return terminalErr
 		}
-		// Authentication is already wrapped by connection initialization or
-		// live-session reauthentication. Return connection loss immediately so
-		// those coordinators can release the authentication gate.
-		if method == methodAuthLoginWithAPIKey && isConnectionError(err) {
-			return err
+		if retryErr != nil {
+			lastErr = retryErr
 		}
-
-		// Check if this is a retryable connection error
-		if !isConnectionError(err) {
-			// Not a connection error, don't retry
-			return err
-		}
-
-		// Check if context is still valid for retry
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		// Don't retry if client is closed
-		c.mu.Lock()
-		closed := c.closed
-		c.mu.Unlock()
-		if closed {
-			return ErrClientClosed
-		}
-
-		if attempt < maxRetries {
-			// Exponential backoff: 1s, 2s, 4s
-			backoff := time.Duration(1<<(attempt-1)) * time.Second
-			klog.V(4).Infof("Request failed with connection error (attempt %d/%d): %v, retrying in %v...",
-				attempt, maxRetries, err, backoff)
-
-			select {
-			case <-time.After(backoff):
-				// Continue to next attempt
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-c.closeCh:
-				return ErrClientClosed
-			}
+		if !retry {
+			break
 		}
 	}
 
 	return fmt.Errorf("request failed after %d attempts: %w", maxRetries, lastErr)
+}
+
+func (c *Client) prepareCallRetry(
+	ctx context.Context,
+	method string,
+	attempt int,
+	maxRetries int,
+	requestEpoch uint64,
+	err error,
+) (retryErr error, retry bool, terminalErr error) {
+
+	// A live connection can lose its server-side session authentication. The
+	// auth method is excluded here so a rejected auth request cannot recurse.
+	if method != methodAuthLoginWithAPIKey && isSessionAuthError(err) {
+		if attempt >= maxRetries {
+			return nil, false, nil
+		}
+		reauthErr := c.reauthenticateAfterSessionLoss(ctx, method, attempt, maxRetries, requestEpoch)
+		if reauthErr != nil && !isConnectionError(reauthErr) {
+			return nil, false, reauthErr
+		}
+		return reauthErr, true, nil
+	}
+
+	// Connection initialization and live-session reauthentication coordinate
+	// auth retries themselves and need the connection loss immediately.
+	if method == methodAuthLoginWithAPIKey && isConnectionError(err) {
+		return nil, false, err
+	}
+	if waitErr := c.waitForCallRetry(ctx, attempt, maxRetries, err); waitErr != nil {
+		return nil, false, waitErr
+	}
+	return nil, true, nil
+}
+
+func (c *Client) reauthenticateAfterSessionLoss(
+	ctx context.Context,
+	method string,
+	attempt int,
+	maxRetries int,
+	requestEpoch uint64,
+) error {
+
+	klog.Warningf("Request %s failed with %s on a live connection (attempt %d/%d), re-authenticating...",
+		method, errNameNotAuthenticated, attempt, maxRetries)
+	if err := c.reauthenticate(ctx, requestEpoch); err != nil {
+		if isConnectionError(err) {
+			return err
+		}
+		return fmt.Errorf("re-authentication after %s failed: %w", errNameNotAuthenticated, err)
+	}
+	return nil
+}
+
+func (c *Client) waitForCallRetry(ctx context.Context, attempt, maxRetries int, err error) error {
+	if !isConnectionError(err) {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return ErrClientClosed
+	}
+	if attempt >= maxRetries {
+		return nil
+	}
+
+	backoff := time.Duration(1<<(attempt-1)) * time.Second
+	klog.V(4).Infof("Request failed with connection error (attempt %d/%d): %v, retrying in %v...",
+		attempt, maxRetries, err, backoff)
+	select {
+	case <-time.After(backoff):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closeCh:
+		return ErrClientClosed
+	}
 }
 
 // callOnce makes a single JSON-RPC 2.0 call attempt.

--- a/pkg/tnsapi/client.go
+++ b/pkg/tnsapi/client.go
@@ -81,6 +81,7 @@ var (
 //nolint:govet // fieldalignment: struct field order optimized for readability over memory layout
 type Client struct {
 	mu            sync.Mutex
+	closeOnce     sync.Once
 	conn          *websocket.Conn
 	pending       map[string]chan *Response
 	closeCh       chan struct{}
@@ -93,12 +94,16 @@ type Client struct {
 	closed        bool
 	reconnecting  bool
 	skipTLSVerify bool // Skip TLS certificate verification
+	authGate      chan struct{}
+	reconnectDone chan struct{}
 
-	// reauthMu serializes session re-authentication after ENOTAUTHENTICATED;
-	// lastReauthAt lets concurrent failing calls reuse a just-completed re-auth
-	// instead of each performing its own.
-	reauthMu     sync.Mutex
-	lastReauthAt time.Time
+	// reauthMu coordinates session re-authentication after ENOTAUTHENTICATED.
+	// Concurrent calls wait on reauthDone and reuse a re-authentication that
+	// completed after their request started.
+	reauthMu      sync.Mutex
+	reauthDone    chan struct{}
+	reauthEpoch   uint64
+	lastReauthErr error
 }
 
 // Request represents a storage API WebSocket request (JSON-RPC 2.0 format).
@@ -204,6 +209,7 @@ func NewClient(url, apiKey string, skipTLSVerify bool) (*Client, error) {
 		maxRetries:    5,
 		retryInterval: 5 * time.Second,
 		skipTLSVerify: skipTLSVerify,
+		authGate:      make(chan struct{}, 1),
 	}
 
 	// Connect to WebSocket with retry logic
@@ -228,6 +234,7 @@ func NewClient(url, apiKey string, skipTLSVerify bool) (*Client, error) {
 				maxRetries:    5,
 				retryInterval: 5 * time.Second,
 				skipTLSVerify: skipTLSVerify,
+				authGate:      make(chan struct{}, 1),
 			}
 		}
 
@@ -249,7 +256,7 @@ func NewClient(url, apiKey string, skipTLSVerify bool) (*Client, error) {
 		go c.pingLoop()
 
 		// Authenticate
-		if err := c.authenticate(); err != nil {
+		if err := c.authenticate(context.Background()); err != nil {
 			c.Close()
 			lastConnErr = err
 
@@ -329,8 +336,17 @@ func (c *Client) connect() error {
 	// Note: coder/websocket handles ping/pong automatically via the underlying connection.
 	// We still run our own ping loop for connection health monitoring and metrics.
 
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		if closeErr := conn.Close(websocket.StatusNormalClosure, "client closed while connecting"); closeErr != nil {
+			klog.V(5).Infof("Failed to close connection created during client shutdown: %v", closeErr)
+		}
+		return ErrClientClosed
+	}
 	c.conn = conn
 	c.connectedAt = time.Now()
+	c.mu.Unlock()
 
 	// Update connection metrics
 	metrics.SetWSConnectionStatus(true)
@@ -339,16 +355,24 @@ func (c *Client) connect() error {
 }
 
 // authenticate performs API key authentication using JSON-RPC 2.0.
-func (c *Client) authenticate() error {
+func (c *Client) authenticate(ctx context.Context) error {
+	if err := c.acquireAuthentication(ctx); err != nil {
+		return err
+	}
+	defer c.releaseAuthentication()
+	return c.authenticateLocked(ctx)
+}
+
+func (c *Client) authenticateLocked(ctx context.Context) error {
 	klog.V(4).Info("Authenticating with storage system using auth.login_with_api_key")
 
 	// Storage system uses JSON-RPC 2.0 for authentication
 	// Call auth.login_with_api_key with the API key
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	authCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	var authResult bool
-	if err := c.Call(ctx, methodAuthLoginWithAPIKey, []interface{}{c.apiKey}, &authResult); err != nil {
+	if err := c.Call(authCtx, methodAuthLoginWithAPIKey, []interface{}{c.apiKey}, &authResult); err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
 
@@ -364,10 +388,17 @@ func (c *Client) authenticate() error {
 // authenticateDirect performs API key authentication by directly reading from WebSocket
 // This is used during reconnection when readLoop is blocked and can't handle responses.
 func (c *Client) authenticateDirect() error {
-	klog.V(4).Info("Authenticating with storage system using auth.login_with_api_key (direct mode)")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+	if err := c.acquireAuthentication(ctx); err != nil {
+		return err
+	}
+	defer c.releaseAuthentication()
+	return c.authenticateDirectLocked(ctx)
+}
+
+func (c *Client) authenticateDirectLocked(ctx context.Context) error {
+	klog.V(4).Info("Authenticating with storage system using auth.login_with_api_key (direct mode)")
 
 	c.mu.Lock()
 
@@ -433,6 +464,21 @@ func (c *Client) authenticateDirect() error {
 	return nil
 }
 
+func (c *Client) acquireAuthentication(ctx context.Context) error {
+	select {
+	case c.authGate <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closeCh:
+		return ErrClientClosed
+	}
+}
+
+func (c *Client) releaseAuthentication() {
+	<-c.authGate
+}
+
 // isSessionAuthError reports whether err is an ENOTAUTHENTICATED error from
 // the storage API — the WebSocket session lost its authentication while the
 // connection itself stayed alive (observed after storage middleware restarts:
@@ -452,23 +498,71 @@ func isSessionAuthError(err error) bool {
 }
 
 // reauthenticate restores session authentication on the live connection after
-// an ENOTAUTHENTICATED response. Serialized so that many concurrent calls
-// failing at once trigger a single auth.login_with_api_key: callers that
-// arrive right after a completed re-authentication reuse its result.
-func (c *Client) reauthenticate() error {
-	c.reauthMu.Lock()
-	defer c.reauthMu.Unlock()
+// an ENOTAUTHENTICATED response. Concurrent callers reuse a re-authentication
+// completed since their request attempt began.
+func (c *Client) reauthenticate(ctx context.Context, requestEpoch uint64) error {
+	for {
+		c.reauthMu.Lock()
+		if c.reauthEpoch != requestEpoch {
+			err := c.lastReauthErr
+			c.reauthMu.Unlock()
+			return err
+		}
+		if reauthDone := c.reauthDone; reauthDone != nil {
+			c.reauthMu.Unlock()
+			select {
+			case <-reauthDone:
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 
-	// Another caller has just re-authenticated this session — reuse it.
-	if time.Since(c.lastReauthAt) < time.Second {
-		return nil
-	}
+		reauthDone := make(chan struct{})
+		c.reauthDone = reauthDone
+		c.reauthMu.Unlock()
 
-	if err := c.authenticate(); err != nil {
+		err := c.acquireAuthentication(ctx)
+		performedAuth := false
+		if err == nil {
+			c.reauthMu.Lock()
+			if c.reauthEpoch != requestEpoch {
+				err = c.lastReauthErr
+			} else {
+				performedAuth = true
+			}
+			c.reauthMu.Unlock()
+			if performedAuth {
+				err = c.authenticateLocked(ctx)
+			}
+			c.releaseAuthentication()
+		}
+
+		c.reauthMu.Lock()
+		// Do not make one caller's cancellation the shared result for callers
+		// that still have time to perform authentication themselves.
+		if performedAuth && ctx.Err() == nil && !isConnectionError(err) {
+			c.reauthEpoch++
+			c.lastReauthErr = err
+		}
+		c.reauthDone = nil
+		close(reauthDone)
+		c.reauthMu.Unlock()
 		return err
 	}
-	c.lastReauthAt = time.Now()
-	return nil
+}
+
+func (c *Client) currentReauthEpoch() uint64 {
+	c.reauthMu.Lock()
+	defer c.reauthMu.Unlock()
+	return c.reauthEpoch
+}
+
+func (c *Client) recordReauthentication(err error) {
+	c.reauthMu.Lock()
+	c.reauthEpoch++
+	c.lastReauthErr = err
+	c.reauthMu.Unlock()
 }
 
 // isConnectionError checks if the error is a connection-related error that should trigger a retry.
@@ -498,7 +592,7 @@ func (c *Client) Call(ctx context.Context, method string, params []interface{}, 
 	var lastErr error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		err := c.callOnce(ctx, method, params, result)
+		requestEpoch, err := c.callOnce(ctx, method, params, result)
 		if err == nil {
 			return nil
 		}
@@ -512,12 +606,25 @@ func (c *Client) Call(ctx context.Context, method string, params []interface{}, 
 		// live connection and retry. The auth call itself is excluded to
 		// avoid recursion.
 		if method != methodAuthLoginWithAPIKey && isSessionAuthError(err) {
+			if attempt == maxRetries {
+				break
+			}
 			klog.Warningf("Request %s failed with %s on a live connection (attempt %d/%d), re-authenticating...",
 				method, errNameNotAuthenticated, attempt, maxRetries)
-			if raErr := c.reauthenticate(); raErr != nil {
+			if raErr := c.reauthenticate(ctx, requestEpoch); raErr != nil {
+				if isConnectionError(raErr) {
+					lastErr = raErr
+					continue
+				}
 				return fmt.Errorf("re-authentication after %s failed: %w", errNameNotAuthenticated, raErr)
 			}
 			continue
+		}
+		// Authentication is already wrapped by connection initialization or
+		// live-session reauthentication. Return connection loss immediately so
+		// those coordinators can release the authentication gate.
+		if method == methodAuthLoginWithAPIKey && isConnectionError(err) {
+			return err
 		}
 
 		// Check if this is a retryable connection error
@@ -560,11 +667,30 @@ func (c *Client) Call(ctx context.Context, method string, params []interface{}, 
 }
 
 // callOnce makes a single JSON-RPC 2.0 call attempt.
-func (c *Client) callOnce(ctx context.Context, method string, params []interface{}, result interface{}) error {
-	c.mu.Lock()
-	if c.closed {
+func (c *Client) callOnce(ctx context.Context, method string, params []interface{}, result interface{}) (uint64, error) {
+	for {
+		c.mu.Lock()
+		if c.closed {
+			c.mu.Unlock()
+			return 0, ErrClientClosed
+		}
+		reconnectDone := c.reconnectDone
+		if reconnectDone == nil {
+			break
+		}
 		c.mu.Unlock()
-		return ErrClientClosed
+		if method == methodAuthLoginWithAPIKey {
+			return 0, ErrConnectionClosed
+		}
+
+		select {
+		case <-reconnectDone:
+			continue
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-c.closeCh:
+			return 0, ErrClientClosed
+		}
 	}
 
 	// Generate request ID
@@ -586,12 +712,16 @@ func (c *Client) callOnce(ctx context.Context, method string, params []interface
 	klog.V(5).Infof("Sending request: method=%s, id=%s", method, id)
 	// Use a short timeout for writing to avoid blocking forever
 	writeCtx, writeCancel := context.WithTimeout(ctx, 10*time.Second)
+	// Keep the authentication generation stable from capture through dispatch.
+	c.reauthMu.Lock()
+	requestEpoch := c.reauthEpoch
 	err := wsjson.Write(writeCtx, c.conn, req)
+	c.reauthMu.Unlock()
 	writeCancel()
 	if err != nil {
 		delete(c.pending, id)
 		c.mu.Unlock()
-		return fmt.Errorf("failed to send request: %w", err)
+		return requestEpoch, fmt.Errorf("failed to send request: %w", err)
 	}
 	metrics.RecordWSMessage("sent")
 	c.mu.Unlock()
@@ -601,25 +731,25 @@ func (c *Client) callOnce(ctx context.Context, method string, params []interface
 	case resp, ok := <-respCh:
 		if !ok {
 			// Channel was closed, connection error occurred
-			return ErrConnectionClosed
+			return requestEpoch, ErrConnectionClosed
 		}
 		metrics.RecordWSMessage("received")
 		if resp.Error != nil {
-			return resp.Error
+			return requestEpoch, resp.Error
 		}
 		if result != nil && resp.Result != nil {
 			if err := json.Unmarshal(resp.Result, result); err != nil {
-				return fmt.Errorf("failed to unmarshal result: %w", err)
+				return requestEpoch, fmt.Errorf("failed to unmarshal result: %w", err)
 			}
 		}
-		return nil
+		return requestEpoch, nil
 	case <-ctx.Done():
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()
-		return ctx.Err()
+		return requestEpoch, ctx.Err()
 	case <-c.closeCh:
-		return ErrClientClosed
+		return requestEpoch, ErrClientClosed
 	}
 }
 
@@ -653,7 +783,7 @@ func (c *Client) cleanupReadLoop() {
 	}
 	c.pending = make(map[string]chan *Response)
 	c.mu.Unlock()
-	close(c.closeCh)
+	c.signalClose()
 }
 
 // handleReadError handles WebSocket read errors with reconnection logic.
@@ -673,6 +803,10 @@ func (c *Client) handleReadError(err error) bool {
 	if closeStatus != websocket.StatusNormalClosure && closeStatus != websocket.StatusGoingAway {
 		klog.Errorf("WebSocket read error: %v", err)
 	}
+	if !c.beginReconnect() {
+		return false
+	}
+	defer c.endReconnect()
 
 	// Attempt to reconnect
 	if c.reconnect() {
@@ -685,20 +819,21 @@ func (c *Client) handleReadError(err error) bool {
 }
 
 // reinitializeConnection performs full connection reinitialization after reconnect failures.
-// Returns true if reinitialization succeeded, false if it failed.
 func (c *Client) reinitializeConnection() bool {
 	klog.Warning("Failed to reconnect after 5 attempts, will reinitialize connection in 30 seconds...")
-	time.Sleep(30 * time.Second)
-
-	klog.Info("Reinitializing WebSocket connection from scratch...")
-	if err := c.connect(); err != nil {
-		klog.Errorf("Connection reinitialization failed: %v, will retry", err)
-		return true // Continue loop to retry
+	select {
+	case <-time.After(30 * time.Second):
+	case <-c.closeCh:
+		return false
 	}
 
-	if err := c.authenticateDirect(); err != nil {
-		klog.Errorf("Re-authentication after reinitialization failed: %v, will retry", err)
-		return true // Continue loop to retry
+	klog.Info("Reinitializing WebSocket connection from scratch...")
+	if err := c.connectAndAuthenticateDirect(); err != nil {
+		if errors.Is(err, ErrClientClosed) {
+			return false
+		}
+		klog.Errorf("Connection reinitialization failed: %v, will retry", err)
+		return true
 	}
 
 	klog.Info("Successfully reinitialized WebSocket connection")
@@ -728,20 +863,6 @@ func (c *Client) processResponse(rawMsg []byte) {
 
 // reconnect attempts to reconnect to the WebSocket and re-authenticate.
 func (c *Client) reconnect() bool {
-	c.mu.Lock()
-	if c.reconnecting {
-		c.mu.Unlock()
-		return false
-	}
-	c.reconnecting = true
-	c.mu.Unlock()
-
-	defer func() {
-		c.mu.Lock()
-		c.reconnecting = false
-		c.mu.Unlock()
-	}()
-
 	klog.Warning("WebSocket connection lost, attempting to reconnect...")
 
 	// Update metrics - connection lost
@@ -785,14 +906,9 @@ func (c *Client) reconnect() bool {
 		c.pending = make(map[string]chan *Response)
 		c.mu.Unlock()
 
-		// Attempt to reconnect
-		if err := c.connect(); err != nil {
-			klog.Errorf("Reconnection attempt %d failed: %v", attempt, err)
-			continue
-		}
-
-		// Re-authenticate using direct read (since readLoop is blocked here)
-		if err := c.authenticateDirect(); err != nil {
+		// Reconnect and authenticate while live re-authentication is excluded;
+		// readLoop is blocked here, so authentication must read directly.
+		if err := c.connectAndAuthenticateDirect(); err != nil {
 			klog.Errorf("Re-authentication attempt %d failed: %v", attempt, err)
 			continue
 		}
@@ -802,6 +918,45 @@ func (c *Client) reconnect() bool {
 	}
 
 	return false
+}
+
+func (c *Client) beginReconnect() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.reconnecting {
+		return false
+	}
+	c.reconnecting = true
+	c.reconnectDone = make(chan struct{})
+	return true
+}
+
+func (c *Client) endReconnect() {
+	c.mu.Lock()
+	c.reconnecting = false
+	close(c.reconnectDone)
+	c.reconnectDone = nil
+	c.mu.Unlock()
+}
+
+func (c *Client) connectAndAuthenticateDirect() error {
+	gateCtx, gateCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer gateCancel()
+	if err := c.acquireAuthentication(gateCtx); err != nil {
+		return fmt.Errorf("failed to acquire authentication gate: %w", err)
+	}
+	defer c.releaseAuthentication()
+
+	if err := c.connect(); err != nil {
+		return err
+	}
+	authCtx, authCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer authCancel()
+	if err := c.authenticateDirectLocked(authCtx); err != nil {
+		return err
+	}
+	c.recordReauthentication(nil)
+	return nil
 }
 
 // pingLoop sends periodic pings to keep the connection alive and detect failures.
@@ -851,21 +1006,29 @@ func (c *Client) pingLoop() {
 // Close closes the client connection.
 func (c *Client) Close() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.closed {
+		c.mu.Unlock()
 		return
 	}
 
 	klog.V(4).Info("Closing storage API client")
 	c.closed = true
+	conn := c.conn
+	c.mu.Unlock()
+	c.signalClose()
 
-	if c.conn != nil {
+	if conn != nil {
 		// coder/websocket Close sends close frame and closes the connection
 		// Ignore close error - we're shutting down anyway
 		//nolint:errcheck,gosec // G104: Intentionally ignoring close error during shutdown
-		c.conn.Close(websocket.StatusNormalClosure, "client closing")
+		conn.Close(websocket.StatusNormalClosure, "client closing")
 	}
+}
+
+func (c *Client) signalClose() {
+	c.closeOnce.Do(func() {
+		close(c.closeCh)
+	})
 }
 
 // Pool API methods

--- a/pkg/tnsapi/client_test.go
+++ b/pkg/tnsapi/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -878,5 +879,200 @@ func TestQueryPool(t *testing.T) {
 				t.Errorf("Pool free = %d, want %d", pool.Properties.Free.Parsed, tt.wantFree)
 			}
 		})
+	}
+}
+
+// enotauthenticatedError mimics the error the storage API returns when the
+// WebSocket session has lost its authentication (e.g. middleware restart on
+// the storage side that keeps TCP connections alive).
+func enotauthenticatedError() *Error {
+	return &Error{
+		Code:    -32001,
+		Message: "Method call error",
+		Data: &ErrorData{
+			Error:     207,
+			ErrorName: "ENOTAUTHENTICATED",
+			Reason:    "[ENOTAUTHENTICATED] Not authenticated",
+		},
+	}
+}
+
+func TestIsSessionAuthError(t *testing.T) {
+	tests := []struct {
+		err  error
+		name string
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "connection error", err: ErrConnectionClosed, want: false},
+		{name: "ENOTAUTHENTICATED in data", err: enotauthenticatedError(), want: true},
+		{
+			name: "ENOTAUTHENTICATED in top-level errname",
+			err:  &Error{ErrorName: "ENOTAUTHENTICATED", Reason: "[ENOTAUTHENTICATED] Not authenticated"},
+			want: true,
+		},
+		{
+			name: "wrapped ENOTAUTHENTICATED",
+			err:  fmt.Errorf("call failed: %w", enotauthenticatedError()),
+			want: true,
+		},
+		{
+			name: "other API error",
+			err:  &Error{Code: 401, Message: "invalid API key"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSessionAuthError(tt.err); got != tt.want {
+				t.Errorf("isSessionAuthError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCallReauthenticatesOnSessionAuthLoss reproduces the session-loss
+// scenario: the server starts answering ENOTAUTHENTICATED on a perfectly
+// healthy connection. Call() must re-authenticate on the live socket and
+// retry the original request instead of failing forever.
+func TestCallReauthenticatesOnSessionAuthLoss(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authCalls := 0
+	dataCalls := 0
+
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+
+			var req Request
+			if err := json.Unmarshal(message, &req); err != nil {
+				continue
+			}
+
+			resp := Response{ID: req.ID}
+
+			mu.Lock()
+			switch req.Method {
+			case "auth.login_with_api_key":
+				authCalls++
+				resp.Result = json.RawMessage(`true`)
+			default:
+				dataCalls++
+				if dataCalls == 1 {
+					// Session silently dropped server-side: the connection
+					// stays open, but calls are no longer authenticated.
+					resp.Error = enotauthenticatedError()
+				} else {
+					resp.Result = json.RawMessage(`true`)
+				}
+			}
+			mu.Unlock()
+
+			respBytes, err := json.Marshal(resp)
+			if err == nil {
+				//nolint:errcheck,gosec // test server write
+				conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var result bool
+	if err := client.Call(ctx, "test.method", nil, &result); err != nil {
+		t.Fatalf("Call() after session auth loss should recover, got error: %v", err)
+	}
+	if !result {
+		t.Error("Call() result = false, want true")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// initial NewClient auth + one re-auth triggered by ENOTAUTHENTICATED
+	if authCalls != 2 {
+		t.Errorf("auth.login_with_api_key calls = %d, want 2 (initial + re-auth)", authCalls)
+	}
+	if dataCalls != 2 {
+		t.Errorf("data calls = %d, want 2 (failed + retried)", dataCalls)
+	}
+}
+
+// TestAuthCallDoesNotRecurseOnSessionAuthLoss guards against infinite
+// recursion: if auth.login_with_api_key itself fails with ENOTAUTHENTICATED,
+// Call() must NOT trigger another re-authentication.
+func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authCalls := 0
+
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+
+			var req Request
+			if err := json.Unmarshal(message, &req); err != nil {
+				continue
+			}
+
+			resp := Response{ID: req.ID}
+
+			mu.Lock()
+			authCalls++
+			if authCalls == 1 {
+				// Let NewClient succeed
+				resp.Result = json.RawMessage(`true`)
+			} else {
+				resp.Error = enotauthenticatedError()
+			}
+			mu.Unlock()
+
+			respBytes, err := json.Marshal(resp)
+			if err == nil {
+				//nolint:errcheck,gosec // test server write
+				conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	// Force lastReauthAt out of the reuse window and re-authenticate: the
+	// auth call fails with ENOTAUTHENTICATED and must surface the error
+	// without recursing.
+	if err := client.reauthenticate(); err == nil {
+		t.Fatal("reauthenticate() should fail when auth itself gets ENOTAUTHENTICATED")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// initial NewClient auth + exactly ONE failed re-auth attempt
+	if authCalls != 2 {
+		t.Errorf("auth.login_with_api_key calls = %d, want 2 (no recursion)", authCalls)
 	}
 }

--- a/pkg/tnsapi/client_test.go
+++ b/pkg/tnsapi/client_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 )
 
 // mockWSServer provides a mock WebSocket server for testing.
@@ -27,6 +28,42 @@ type mockWSServer struct {
 	disconnectAfter int // Disconnect after N messages (0 = never)
 	mu              sync.Mutex
 	msgCount        int
+}
+
+type concurrentReauthState struct { //nolint:govet // Field order follows synchronization and state semantics.
+	mu              sync.Mutex
+	authCalls       int
+	dataCalls       int
+	pendingReauthID string
+	callerCount     int
+}
+
+func (s *concurrentReauthState) handle(req Request) []Response {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if req.Method == methodAuthLoginWithAPIKey {
+		s.authCalls++
+		if s.authCalls > 1 && s.dataCalls < s.callerCount {
+			s.pendingReauthID = req.ID
+			return nil
+		}
+		return []Response{{ID: req.ID, Result: json.RawMessage(`true`)}}
+	}
+
+	s.dataCalls++
+	resp := Response{ID: req.ID, Result: json.RawMessage(`true`)}
+	if s.dataCalls <= s.callerCount {
+		resp.Result = nil
+		resp.Error = enotauthenticatedError()
+	}
+	if s.dataCalls != s.callerCount || s.pendingReauthID == "" {
+		return []Response{resp}
+	}
+
+	reauthResp := Response{ID: s.pendingReauthID, Result: json.RawMessage(`true`)}
+	s.pendingReauthID = ""
+	return []Response{resp, reauthResp}
 }
 
 func newMockWSServer() *mockWSServer {
@@ -112,6 +149,21 @@ func (m *mockWSServer) defaultHandler(ctx context.Context, conn *websocket.Conn)
 		respBytes, errMarshal := json.Marshal(resp)
 		if errMarshal == nil {
 			conn.Write(ctx, websocket.MessageText, respBytes)
+		}
+	}
+}
+
+func serveMockRequests(conn *websocket.Conn, handle func(Request) []Response) {
+	ctx := context.Background()
+	for {
+		var req Request
+		if err := wsjson.Read(ctx, conn, &req); err != nil {
+			return
+		}
+		for _, resp := range handle(req) {
+			if err := wsjson.Write(ctx, conn, resp); err != nil {
+				return
+			}
 		}
 	}
 }
@@ -410,26 +462,14 @@ func TestCallWaitsForReconnectAuthentication(t *testing.T) {
 	var mu sync.Mutex
 	dataCalls := 0
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
+		serveMockRequests(conn, func(req Request) []Response {
 			if req.Method != methodAuthLoginWithAPIKey {
 				mu.Lock()
 				dataCalls++
 				mu.Unlock()
 			}
-			respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Result: json.RawMessage(`true`)})
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
+			return []Response{{ID: req.ID, Result: json.RawMessage(`true`)}}
+		})
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1044,20 +1084,8 @@ func TestCallReauthenticatesOnSessionAuthLoss(t *testing.T) {
 	dataCalls := 0
 
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
-
+		serveMockRequests(conn, func(req Request) []Response {
 			resp := Response{ID: req.ID}
-
 			mu.Lock()
 			switch req.Method {
 			case "auth.login_with_api_key":
@@ -1074,12 +1102,8 @@ func TestCallReauthenticatesOnSessionAuthLoss(t *testing.T) {
 				}
 			}
 			mu.Unlock()
-
-			respBytes, marshalErr := json.Marshal(resp)
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
+			return []Response{resp}
+		})
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1119,17 +1143,7 @@ func TestCallReauthenticatesOnRapidSecondSessionLoss(t *testing.T) {
 	authCalls := 0
 	dataCalls := 0
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
-
+		serveMockRequests(conn, func(req Request) []Response {
 			resp := Response{ID: req.ID}
 			mu.Lock()
 			if req.Method == methodAuthLoginWithAPIKey {
@@ -1145,12 +1159,8 @@ func TestCallReauthenticatesOnRapidSecondSessionLoss(t *testing.T) {
 				}
 			}
 			mu.Unlock()
-
-			respBytes, marshalErr := json.Marshal(resp)
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
+			return []Response{resp}
+		})
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1191,61 +1201,9 @@ func TestConcurrentCallsShareReauthentication(t *testing.T) {
 	server := newMockWSServer()
 	defer server.Close()
 
-	var mu sync.Mutex
-	authCalls := 0
-	dataCalls := 0
-	pendingReauthID := ""
+	state := concurrentReauthState{callerCount: callerCount}
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		writeResponse := func(resp Response) {
-			respBytes, marshalErr := json.Marshal(resp)
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
-
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
-
-			mu.Lock()
-			if req.Method == methodAuthLoginWithAPIKey {
-				authCalls++
-				if authCalls > 1 && dataCalls < callerCount {
-					pendingReauthID = req.ID
-					mu.Unlock()
-					continue
-				}
-				mu.Unlock()
-				writeResponse(Response{ID: req.ID, Result: json.RawMessage(`true`)})
-				continue
-			}
-
-			dataCalls++
-			currentDataCalls := dataCalls
-			reauthID := ""
-			if dataCalls == callerCount {
-				reauthID = pendingReauthID
-				pendingReauthID = ""
-			}
-			mu.Unlock()
-
-			resp := Response{ID: req.ID, Result: json.RawMessage(`true`)}
-			if currentDataCalls <= callerCount {
-				resp.Result = nil
-				resp.Error = enotauthenticatedError()
-			}
-			writeResponse(resp)
-			if reauthID != "" {
-				writeResponse(Response{ID: reauthID, Result: json.RawMessage(`true`)})
-			}
-		}
+		serveMockRequests(conn, state.handle)
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1277,13 +1235,13 @@ func TestConcurrentCallsShareReauthentication(t *testing.T) {
 		}
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
-	if authCalls != 2 {
-		t.Errorf("auth calls = %d, want 2 (initial + one shared re-authentication)", authCalls)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.authCalls != 2 {
+		t.Errorf("auth calls = %d, want 2 (initial + one shared re-authentication)", state.authCalls)
 	}
-	if dataCalls != callerCount*2 {
-		t.Errorf("data calls = %d, want %d", dataCalls, callerCount*2)
+	if state.dataCalls != callerCount*2 {
+		t.Errorf("data calls = %d, want %d", state.dataCalls, callerCount*2)
 	}
 }
 
@@ -1293,34 +1251,16 @@ func TestCallCancellationStopsReauthentication(t *testing.T) {
 
 	authCalls := 0
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
-
+		serveMockRequests(conn, func(req Request) []Response {
 			if req.Method == methodAuthLoginWithAPIKey {
 				authCalls++
 				if authCalls > 1 {
-					continue
+					return nil
 				}
-				respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Result: json.RawMessage(`true`)})
-				if marshalErr == nil {
-					_ = conn.Write(ctx, websocket.MessageText, respBytes)
-				}
-				continue
+				return []Response{{ID: req.ID, Result: json.RawMessage(`true`)}}
 			}
-
-			respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Error: enotauthenticatedError()})
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
+			return []Response{{ID: req.ID, Error: enotauthenticatedError()}}
+		})
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1348,37 +1288,19 @@ func TestConcurrentCallsShareInternalAuthenticationTimeout(t *testing.T) {
 	var mu sync.Mutex
 	authCalls := 0
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
-
+		serveMockRequests(conn, func(req Request) []Response {
 			if req.Method == methodAuthLoginWithAPIKey {
 				mu.Lock()
 				authCalls++
 				currentAuthCalls := authCalls
 				mu.Unlock()
 				if currentAuthCalls > 1 {
-					continue
+					return nil
 				}
-				respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Result: json.RawMessage(`true`)})
-				if marshalErr == nil {
-					_ = conn.Write(ctx, websocket.MessageText, respBytes)
-				}
-				continue
+				return []Response{{ID: req.ID, Result: json.RawMessage(`true`)}}
 			}
-
-			respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Error: enotauthenticatedError()})
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
+			return []Response{{ID: req.ID, Error: enotauthenticatedError()}}
+		})
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1416,17 +1338,7 @@ func TestCallDoesNotReauthenticateAfterFinalAttempt(t *testing.T) {
 	authCalls := 0
 	dataCalls := 0
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
-
+		serveMockRequests(conn, func(req Request) []Response {
 			resp := Response{ID: req.ID}
 			mu.Lock()
 			if req.Method == methodAuthLoginWithAPIKey {
@@ -1437,12 +1349,8 @@ func TestCallDoesNotReauthenticateAfterFinalAttempt(t *testing.T) {
 				resp.Error = enotauthenticatedError()
 			}
 			mu.Unlock()
-
-			respBytes, marshalErr := json.Marshal(resp)
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
+			return []Response{resp}
+		})
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1478,20 +1386,8 @@ func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
 	authCalls := 0
 
 	server.handler = func(conn *websocket.Conn) {
-		ctx := context.Background()
-		for {
-			_, message, readErr := conn.Read(ctx)
-			if readErr != nil {
-				return
-			}
-
-			var req Request
-			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
-				continue
-			}
-
+		serveMockRequests(conn, func(req Request) []Response {
 			resp := Response{ID: req.ID}
-
 			mu.Lock()
 			authCalls++
 			if authCalls == 1 {
@@ -1501,12 +1397,8 @@ func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
 				resp.Error = enotauthenticatedError()
 			}
 			mu.Unlock()
-
-			respBytes, marshalErr := json.Marshal(resp)
-			if marshalErr == nil {
-				_ = conn.Write(ctx, websocket.MessageText, respBytes)
-			}
-		}
+			return []Response{resp}
+		})
 	}
 
 	client, err := NewClient(server.URL(), "test-api-key", false)
@@ -1526,5 +1418,154 @@ func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
 	// initial NewClient auth + exactly ONE failed re-auth attempt
 	if authCalls != 2 {
 		t.Errorf("auth.login_with_api_key calls = %d, want 2 (no recursion)", authCalls)
+	}
+}
+
+func TestAuthenticationGateStopsOnContextOrClose(t *testing.T) {
+	//nolint:govet // Field order keeps the test case readable.
+	tests := []struct {
+		name    string
+		prepare func(context.CancelFunc, chan struct{})
+		wantErr error
+	}{
+		{
+			name: "canceled context",
+			prepare: func(cancel context.CancelFunc, _ chan struct{}) {
+				cancel()
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "closed client",
+			prepare: func(_ context.CancelFunc, closeCh chan struct{}) {
+				close(closeCh)
+			},
+			wantErr: ErrClientClosed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{
+				authGate: make(chan struct{}, 1),
+				closeCh:  make(chan struct{}),
+			}
+			client.authGate <- struct{}{}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			tt.prepare(cancel, client.closeCh)
+
+			if err := client.acquireAuthentication(ctx); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("acquireAuthentication() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReauthenticationSynchronizationBranches(t *testing.T) {
+	t.Run("waiter cancellation", func(t *testing.T) {
+		done := make(chan struct{})
+		client := &Client{reauthDone: done}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		if err := client.reauthenticate(ctx, 0); !errors.Is(err, context.Canceled) {
+			t.Fatalf("reauthenticate() error = %v, want context canceled", err)
+		}
+		if client.reauthDone != done {
+			t.Fatal("waiter cancellation changed the active reauthentication")
+		}
+	})
+
+	t.Run("stale epoch after gate", func(t *testing.T) {
+		wantErr := errors.New("reauthentication already completed")
+		client := &Client{
+			authGate:      make(chan struct{}, 1),
+			closeCh:       make(chan struct{}),
+			reauthEpoch:   2,
+			lastReauthErr: wantErr,
+		}
+
+		performed, err := client.performReauthentication(context.Background(), 1)
+		if !errors.Is(err, wantErr) || performed {
+			t.Fatalf("performReauthentication() = (%v, %v), want (%v, false)", err, performed, wantErr)
+		}
+	})
+
+	t.Run("record completion", func(t *testing.T) {
+		client := &Client{}
+		wantErr := errors.New("authentication rejected")
+		client.recordReauthentication(wantErr)
+
+		if client.currentReauthEpoch() != 1 {
+			t.Fatalf("reauth epoch = %d, want 1", client.currentReauthEpoch())
+		}
+		if !errors.Is(client.lastReauthErr, wantErr) {
+			t.Fatalf("last reauthentication error = %v, want %v", client.lastReauthErr, wantErr)
+		}
+	})
+}
+
+func TestWaitForCallRetry(t *testing.T) {
+	//nolint:govet // Field order keeps the test case readable.
+	tests := []struct {
+		err     error
+		prepare func(*Client, context.CancelFunc)
+		name    string
+		attempt int
+		wantErr error
+	}{
+		{name: "non-connection error", err: errors.New("invalid request"), wantErr: errors.New("invalid request")},
+		{
+			name: "canceled context",
+			err:  ErrConnectionClosed,
+			prepare: func(_ *Client, cancel context.CancelFunc) {
+				cancel()
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "closed client",
+			err:  ErrConnectionClosed,
+			prepare: func(client *Client, _ context.CancelFunc) {
+				client.closed = true
+			},
+			wantErr: ErrClientClosed,
+		},
+		{name: "final attempt", err: ErrConnectionClosed, attempt: 3},
+		{
+			name: "close during backoff",
+			err:  ErrConnectionClosed,
+			prepare: func(client *Client, _ context.CancelFunc) {
+				close(client.closeCh)
+			},
+			wantErr: ErrClientClosed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{closeCh: make(chan struct{})}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.prepare != nil {
+				tt.prepare(client, cancel)
+			}
+			attempt := tt.attempt
+			if attempt == 0 {
+				attempt = 1
+			}
+
+			err := client.waitForCallRetry(ctx, attempt, 3, tt.err)
+			if tt.name == "non-connection error" {
+				if err == nil || err.Error() != tt.wantErr.Error() {
+					t.Fatalf("waitForCallRetry() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("waitForCallRetry() error = %v, want %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/tnsapi/client_test.go
+++ b/pkg/tnsapi/client_test.go
@@ -403,6 +403,103 @@ func TestClientCallAfterClose(t *testing.T) {
 	}
 }
 
+func TestCallWaitsForReconnectAuthentication(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	dataCalls := 0
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
+				return
+			}
+			var req Request
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
+				continue
+			}
+			if req.Method != methodAuthLoginWithAPIKey {
+				mu.Lock()
+				dataCalls++
+				mu.Unlock()
+			}
+			respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Result: json.RawMessage(`true`)})
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+	if !client.beginReconnect() {
+		t.Fatal("beginReconnect() reported an unexpected active reconnect")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if authErr := client.authenticate(ctx); !errors.Is(authErr, ErrConnectionClosed) {
+		client.endReconnect()
+		t.Fatalf("authenticate() during reconnect error = %v, want ErrConnectionClosed", authErr)
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- client.Call(ctx, "test.method", nil, nil)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	callsWhileReconnecting := dataCalls
+	mu.Unlock()
+	client.endReconnect()
+	if callsWhileReconnecting != 0 {
+		t.Fatalf("data calls during reconnect = %d, want 0", callsWhileReconnecting)
+	}
+	if callErr := <-result; callErr != nil {
+		t.Fatalf("Call() after reconnect completed failed: %v", callErr)
+	}
+}
+
+func TestCloseStopsReconnectWaitersAndPreventsReconnect(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	if !client.beginReconnect() {
+		t.Fatal("beginReconnect() reported an unexpected active reconnect")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- client.Call(ctx, "test.method", nil, nil)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	client.Close()
+	select {
+	case callErr := <-result:
+		if !errors.Is(callErr, ErrClientClosed) {
+			t.Fatalf("Call() after Close() error = %v, want ErrClientClosed", callErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close() did not unblock a call waiting for reconnect")
+	}
+	client.endReconnect()
+	if connectErr := client.connect(); !errors.Is(connectErr, ErrClientClosed) {
+		t.Fatalf("connect() after Close() error = %v, want ErrClientClosed", connectErr)
+	}
+}
+
 // TestClientReconnection is skipped because testing reconnection logic
 // properly would require modifying production code to make reconnection
 // cancellable via closeCh. The reconnection logic is tested indirectly
@@ -565,6 +662,7 @@ func TestAuthenticateDirect(t *testing.T) {
 				closeCh:       make(chan struct{}),
 				maxRetries:    5,
 				retryInterval: 5 * time.Second,
+				authGate:      make(chan struct{}, 1),
 			}
 
 			// Connect manually
@@ -948,13 +1046,13 @@ func TestCallReauthenticatesOnSessionAuthLoss(t *testing.T) {
 	server.handler = func(conn *websocket.Conn) {
 		ctx := context.Background()
 		for {
-			_, message, err := conn.Read(ctx)
-			if err != nil {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
 				return
 			}
 
 			var req Request
-			if err := json.Unmarshal(message, &req); err != nil {
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
 				continue
 			}
 
@@ -977,10 +1075,9 @@ func TestCallReauthenticatesOnSessionAuthLoss(t *testing.T) {
 			}
 			mu.Unlock()
 
-			respBytes, err := json.Marshal(resp)
-			if err == nil {
-				//nolint:errcheck,gosec // test server write
-				conn.Write(ctx, websocket.MessageText, respBytes)
+			respBytes, marshalErr := json.Marshal(resp)
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
 			}
 		}
 	}
@@ -1013,6 +1110,363 @@ func TestCallReauthenticatesOnSessionAuthLoss(t *testing.T) {
 	}
 }
 
+func TestCallReauthenticatesOnRapidSecondSessionLoss(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authenticated := false
+	authCalls := 0
+	dataCalls := 0
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
+				return
+			}
+			var req Request
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
+				continue
+			}
+
+			resp := Response{ID: req.ID}
+			mu.Lock()
+			if req.Method == methodAuthLoginWithAPIKey {
+				authCalls++
+				authenticated = true
+				resp.Result = json.RawMessage(`true`)
+			} else {
+				dataCalls++
+				if authenticated {
+					resp.Result = json.RawMessage(`true`)
+				} else {
+					resp.Error = enotauthenticatedError()
+				}
+			}
+			mu.Unlock()
+
+			respBytes, marshalErr := json.Marshal(resp)
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for call := 1; call <= 2; call++ {
+		mu.Lock()
+		authenticated = false
+		mu.Unlock()
+
+		var result bool
+		if callErr := client.Call(ctx, "test.method", nil, &result); callErr != nil {
+			t.Fatalf("Call() %d after session auth loss failed: %v", call, callErr)
+		}
+		if !result {
+			t.Fatalf("Call() %d result = false, want true", call)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if authCalls != 3 {
+		t.Errorf("auth calls = %d, want 3 (initial + two re-authentications)", authCalls)
+	}
+	if dataCalls != 4 {
+		t.Errorf("data calls = %d, want 4 (two failed + two retried)", dataCalls)
+	}
+}
+
+func TestConcurrentCallsShareReauthentication(t *testing.T) {
+	const callerCount = 8
+
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authCalls := 0
+	dataCalls := 0
+	pendingReauthID := ""
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		writeResponse := func(resp Response) {
+			respBytes, marshalErr := json.Marshal(resp)
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+
+		for {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
+				return
+			}
+			var req Request
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
+				continue
+			}
+
+			mu.Lock()
+			if req.Method == methodAuthLoginWithAPIKey {
+				authCalls++
+				if authCalls > 1 && dataCalls < callerCount {
+					pendingReauthID = req.ID
+					mu.Unlock()
+					continue
+				}
+				mu.Unlock()
+				writeResponse(Response{ID: req.ID, Result: json.RawMessage(`true`)})
+				continue
+			}
+
+			dataCalls++
+			currentDataCalls := dataCalls
+			reauthID := ""
+			if dataCalls == callerCount {
+				reauthID = pendingReauthID
+				pendingReauthID = ""
+			}
+			mu.Unlock()
+
+			resp := Response{ID: req.ID, Result: json.RawMessage(`true`)}
+			if currentDataCalls <= callerCount {
+				resp.Result = nil
+				resp.Error = enotauthenticatedError()
+			}
+			writeResponse(resp)
+			if reauthID != "" {
+				writeResponse(Response{ID: reauthID, Result: json.RawMessage(`true`)})
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	results := make(chan error, callerCount)
+	for range callerCount {
+		go func() {
+			var result bool
+			if callErr := client.Call(ctx, "test.method", nil, &result); callErr != nil {
+				results <- callErr
+				return
+			}
+			if !result {
+				results <- errors.New("call returned false")
+				return
+			}
+			results <- nil
+		}()
+	}
+	for range callerCount {
+		if callErr := <-results; callErr != nil {
+			t.Fatalf("concurrent Call() failed: %v", callErr)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if authCalls != 2 {
+		t.Errorf("auth calls = %d, want 2 (initial + one shared re-authentication)", authCalls)
+	}
+	if dataCalls != callerCount*2 {
+		t.Errorf("data calls = %d, want %d", dataCalls, callerCount*2)
+	}
+}
+
+func TestCallCancellationStopsReauthentication(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	authCalls := 0
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
+				return
+			}
+			var req Request
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
+				continue
+			}
+
+			if req.Method == methodAuthLoginWithAPIKey {
+				authCalls++
+				if authCalls > 1 {
+					continue
+				}
+				respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Result: json.RawMessage(`true`)})
+				if marshalErr == nil {
+					_ = conn.Write(ctx, websocket.MessageText, respBytes)
+				}
+				continue
+			}
+
+			respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Error: enotauthenticatedError()})
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	callErr := client.Call(ctx, "test.method", nil, nil)
+	if !errors.Is(callErr, context.DeadlineExceeded) {
+		t.Fatalf("Call() error = %v, want context deadline exceeded", callErr)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("Call() ignored caller cancellation for %v", elapsed)
+	}
+}
+
+func TestConcurrentCallsShareInternalAuthenticationTimeout(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authCalls := 0
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
+				return
+			}
+			var req Request
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
+				continue
+			}
+
+			if req.Method == methodAuthLoginWithAPIKey {
+				mu.Lock()
+				authCalls++
+				currentAuthCalls := authCalls
+				mu.Unlock()
+				if currentAuthCalls > 1 {
+					continue
+				}
+				respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Result: json.RawMessage(`true`)})
+				if marshalErr == nil {
+					_ = conn.Write(ctx, websocket.MessageText, respBytes)
+				}
+				continue
+			}
+
+			respBytes, marshalErr := json.Marshal(Response{ID: req.ID, Error: enotauthenticatedError()})
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			results <- client.Call(ctx, "test.method", nil, nil)
+		}()
+	}
+	for range 2 {
+		if callErr := <-results; !errors.Is(callErr, context.DeadlineExceeded) {
+			t.Fatalf("Call() error = %v, want shared internal authentication timeout", callErr)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if authCalls != 2 {
+		t.Errorf("auth calls = %d, want 2 (initial + one shared timed-out re-authentication)", authCalls)
+	}
+}
+
+func TestCallDoesNotReauthenticateAfterFinalAttempt(t *testing.T) {
+	server := newMockWSServer()
+	defer server.Close()
+
+	var mu sync.Mutex
+	authCalls := 0
+	dataCalls := 0
+	server.handler = func(conn *websocket.Conn) {
+		ctx := context.Background()
+		for {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
+				return
+			}
+			var req Request
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
+				continue
+			}
+
+			resp := Response{ID: req.ID}
+			mu.Lock()
+			if req.Method == methodAuthLoginWithAPIKey {
+				authCalls++
+				resp.Result = json.RawMessage(`true`)
+			} else {
+				dataCalls++
+				resp.Error = enotauthenticatedError()
+			}
+			mu.Unlock()
+
+			respBytes, marshalErr := json.Marshal(resp)
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
+			}
+		}
+	}
+
+	client, err := NewClient(server.URL(), "test-api-key", false)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cleanupClient(client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if callErr := client.Call(ctx, "test.method", nil, nil); callErr == nil {
+		t.Fatal("Call() succeeded despite repeated session authentication errors")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if authCalls != 3 {
+		t.Errorf("auth calls = %d, want 3 (initial + two retryable attempts)", authCalls)
+	}
+	if dataCalls != 3 {
+		t.Errorf("data calls = %d, want 3", dataCalls)
+	}
+}
+
 // TestAuthCallDoesNotRecurseOnSessionAuthLoss guards against infinite
 // recursion: if auth.login_with_api_key itself fails with ENOTAUTHENTICATED,
 // Call() must NOT trigger another re-authentication.
@@ -1026,13 +1480,13 @@ func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
 	server.handler = func(conn *websocket.Conn) {
 		ctx := context.Background()
 		for {
-			_, message, err := conn.Read(ctx)
-			if err != nil {
+			_, message, readErr := conn.Read(ctx)
+			if readErr != nil {
 				return
 			}
 
 			var req Request
-			if err := json.Unmarshal(message, &req); err != nil {
+			if unmarshalErr := json.Unmarshal(message, &req); unmarshalErr != nil {
 				continue
 			}
 
@@ -1048,10 +1502,9 @@ func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
 			}
 			mu.Unlock()
 
-			respBytes, err := json.Marshal(resp)
-			if err == nil {
-				//nolint:errcheck,gosec // test server write
-				conn.Write(ctx, websocket.MessageText, respBytes)
+			respBytes, marshalErr := json.Marshal(resp)
+			if marshalErr == nil {
+				_ = conn.Write(ctx, websocket.MessageText, respBytes)
 			}
 		}
 	}
@@ -1062,10 +1515,9 @@ func TestAuthCallDoesNotRecurseOnSessionAuthLoss(t *testing.T) {
 	}
 	defer cleanupClient(client)
 
-	// Force lastReauthAt out of the reuse window and re-authenticate: the
-	// auth call fails with ENOTAUTHENTICATED and must surface the error
+	// The auth call fails with ENOTAUTHENTICATED and must surface the error
 	// without recursing.
-	if err := client.reauthenticate(); err == nil {
+	if err := client.reauthenticate(context.Background(), client.currentReauthEpoch()); err == nil {
 		t.Fatal("reauthenticate() should fail when auth itself gets ENOTAUTHENTICATED")
 	}
 


### PR DESCRIPTION
## Credit

This work is based on and explicitly credits @Roulettiq's original implementation in #193. Their commit is preserved in this branch with its original authorship; this maintainer-owned PR adds concurrency, reconnect, cancellation, and retry hardening so repository secrets can run the complete CI and Sonar validation.

Supersedes #193.

## Summary

- detect `ENOTAUTHENTICATED` responses when the WebSocket remains connected and retry the original RPC after authenticating again
- coalesce concurrent session failures into one shared reauthentication without a time-window heuristic
- handle rapid consecutive session losses using an authentication generation captured with request dispatch
- propagate caller cancellation and avoid authentication after the final request attempt
- serialize live and reconnect authentication so direct reads cannot consume unrelated responses
- block RPC dispatch until reconnect authentication completes and prevent reconnect from reviving a closed client
- add regression tests for concurrent failures, rapid repeated loss, internal/caller timeouts, reconnect coordination, shutdown, and recursion prevention

## Validation

- `go test -short ./pkg/... ./cmd/kubectl-tns-csi/...`
- `go test -race ./pkg/tnsapi`
- `golangci-lint run --config .golangci.yml ./...`
- `go build ./cmd/tns-csi-driver ./cmd/kubectl-tns-csi`
- final concurrency review: no findings

A local CSI sanity run reproduced the existing single-writer mock-state failure in untouched driver/sanity code; current-main GitHub sanity checks are green and this PR changes only `pkg/tnsapi`.